### PR TITLE
decrease validation frequency;add flag to control

### DIFF
--- a/careless/args/crossvalidation.py
+++ b/careless/args/crossvalidation.py
@@ -51,4 +51,12 @@ args_and_kwargs = (
             "default": 1,
         },
     ),
+    (
+        ("--validation-frequency",),
+        {
+            "help": "During training, set how frequently to evaluate the model on the test set. This is an integer >= 1 which defaults to 10 for once every 10 steps.",
+            "type": int,
+            "default": 10,
+        },
+    ),
 )

--- a/careless/careless.py
+++ b/careless/careless.py
@@ -47,12 +47,14 @@ def run_careless(parser):
     if parser.freeze_structure_factors:
         model.surrogate_posterior.trainable = False
 
+    validation_frequency = parser.validation_frequency
 
     history = model.train_model(
         tuple(map(tf.convert_to_tensor, train)),
         parser.iterations,
         message="Training",
         validation_data=test,
+        validation_frequency=validation_frequency,
     )
 
     for i,ds in enumerate(dm.get_results(model.surrogate_posterior, inputs=train)):

--- a/careless/models/merging/variational.py
+++ b/careless/models/merging/variational.py
@@ -149,7 +149,7 @@ class VariationalMergingModel(tfk.Model, BaseModel):
 
         return ipred
 
-    def train_model(self, data, steps, message=None, format_string="{:0.2e}", validation_data=None):
+    def train_model(self, data, steps, message=None, format_string="{:0.2e}", validation_data=None, validation_frequency=10):
         """
         Alternative to the keras backed VariationalMergingModel.fit method. This method is much faster at the moment but less flexible.
         """
@@ -171,7 +171,8 @@ class VariationalMergingModel(tfk.Model, BaseModel):
         for i in bar:
             _history = train_step((self, data))
             if validation_data is not None:
-                validation_metrics = self.test_on_batch(validation_data, return_dict=True)
+                if i%validation_frequency==0:
+                    validation_metrics = self.test_on_batch(validation_data, return_dict=True)
                 _history['NLL_val'] = val_scale * validation_metrics['NLL']
 
             pf = {}


### PR DESCRIPTION
Running the model on the test data and computing metrics does not need to happen at every training step. This slows down training at least 2-fold for no reason.  This PR sets the default behavior to validate the model every 10 training steps and adds a flag, `--validation-frequency` to control the behavior.