### PR TITLE
Standardize metadata

### DIFF
--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -40,4 +40,10 @@ args_and_kwargs = (
         "type": float, 
         "default" : 1e-7,
     }),
+
+    (("--disable-metadata-standardization",), {
+        "help": "By default careless will convert metadata to z-scores. This flag disables that behavior. In general, unstandardized metadata will lead to unstable optimization. However, this flag might be useful if the user wants to use their own normalization scheme." ,
+        "action": "store_false", 
+        "dest" : "standardize_metadata", 
+    }),
 )

--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -13,6 +13,20 @@ def get_first_key_of_dtype(ds, dtype):
         return match
     return None
 
+def standardize_metadata(metadata):
+    """
+    Standardize metadata ignoring columns with zero std deviation. 
+    """
+    std = metadata.std(0)
+    zeros = (std == 0.)
+    if np.any(zeros):
+        import warnings
+        warnings.warn("Metadata column with zero standard deviation will not be standardized.")
+
+    metadata[:,~zeros] = (metadata[:,~zeros] - metadata[:,~zeros].mean(0)) / metadata[:,~zeros].std(0)
+    return metadata
+    
+
 class DataFormatter():
     """
     Base class for formatting inputs. This class should not be used directly. To extend this class,
@@ -309,7 +323,7 @@ class MonoFormatter(DataFormatter):
         """
         data['dHKL'] = data.dHKL**-2.
         metadata = data[self.metadata_keys].to_numpy('float32')
-        metadata = (metadata - metadata.mean(0)) / metadata.std(0)
+        metadata = standardize_metadata(metadata)
 
         if self.positional_encoding_keys is not None:
             to_encode = data[self.positional_encoding_keys].to_numpy('float32')
@@ -554,7 +568,7 @@ class LaueFormatter(DataFormatter):
 
         data['dHKL'] = data.dHKL**-2.
         metadata = data[self.metadata_keys].to_numpy('float32')
-        metadata = (metadata - metadata.mean(0)) / metadata.std(0)
+        metadata = standardize_metadata(metadata)
 
         if self.positional_encoding_keys is not None:
             to_encode = data[self.positional_encoding_keys].to_numpy('float32')

--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -154,6 +154,7 @@ class MonoFormatter(DataFormatter):
             positional_encoding_keys=None,
             encoding_bit_depth=5,
             spacegroups = None,
+            standardize = True,
         ):
         """
         TODO: fix this
@@ -173,6 +174,8 @@ class MonoFormatter(DataFormatter):
             raise a ValueError.
         spacegroups : list (optional)
             Optional list of spacegroups. 1 Per input file
+        standardize : bool (optional)
+            Whether to standardize the metadata columns. The default is True.
         """
         self.intensity_key = intensity_key
         self.uncertainty_key = uncertainty_key
@@ -186,6 +189,7 @@ class MonoFormatter(DataFormatter):
         self.positional_encoding_keys = positional_encoding_keys
         self.ecoding_bit_depth = encoding_bit_depth
         self.spacegroups = spacegroups
+        self.standardize = standardize
 
     @classmethod
     def from_parser(cls, parser):
@@ -217,6 +221,7 @@ class MonoFormatter(DataFormatter):
             pe_keys,
             parser.positional_encoding_frequencies,
             spacegroups,
+            standardize=parser.standardize_metadata,
         )
 
     def prep_dataset(self, ds, spacegroup=None, inplace=True):
@@ -323,7 +328,9 @@ class MonoFormatter(DataFormatter):
         """
         data['dHKL'] = data.dHKL**-2.
         metadata = data[self.metadata_keys].to_numpy('float32')
-        metadata = standardize_metadata(metadata)
+
+        if self.standardize:
+            metadata = standardize_metadata(metadata)
 
         if self.positional_encoding_keys is not None:
             to_encode = data[self.positional_encoding_keys].to_numpy('float32')
@@ -365,6 +372,7 @@ class LaueFormatter(DataFormatter):
             positional_encoding_keys=None,
             encoding_bit_depth=5,
             spacegroups=None,
+            standardize=True,
         ):
 
         """
@@ -392,6 +400,8 @@ class LaueFormatter(DataFormatter):
             raise a ValueError.
         spacegroups : list (optional)
             Optional list of spacegroups. 1 Per input file.
+        standardize : bool (optional)
+            Whether to standardize the metadata columns. The default is True.
         """
         self.wavelength_key = wavelength_key
         self.lam_min = lam_min
@@ -408,6 +418,7 @@ class LaueFormatter(DataFormatter):
         self.positional_encoding_keys = positional_encoding_keys
         self.ecoding_bit_depth = encoding_bit_depth
         self.spacegroups = spacegroups
+        self.standardize = standardize
 
     @classmethod
     def from_parser(cls, parser):
@@ -444,6 +455,7 @@ class LaueFormatter(DataFormatter):
             pe_keys,
             parser.positional_encoding_frequencies,
             spacegroups=None,
+            standardize=parser.standardize_metadata,
         )
 
     def prep_dataset(self, ds, spacegroup=None):
@@ -568,7 +580,9 @@ class LaueFormatter(DataFormatter):
 
         data['dHKL'] = data.dHKL**-2.
         metadata = data[self.metadata_keys].to_numpy('float32')
-        metadata = standardize_metadata(metadata)
+
+        if self.standardize:
+            metadata = standardize_metadata(metadata)
 
         if self.positional_encoding_keys is not None:
             to_encode = data[self.positional_encoding_keys].to_numpy('float32')


### PR DESCRIPTION
This PR does the following
 1) During metadata standardization, careless will now ignore columns with standard deviation of zero. The user will get a warning message if any such columns are detected.  
 2) Add a new `--disable-metadata-standardization` flag to give users more control over how metadata are pre-processed. This might be  useful in situations that involve pre-training / transfer learning. 