### PR TITLE
add --overall flag to careless.ccpred

### DIFF
--- a/tests/stats/test_cc.py
+++ b/tests/stats/test_cc.py
@@ -58,16 +58,20 @@ def test_ccanom(xval_mtz, method, bins):
 
 
 @pytest.mark.parametrize("bins", [1, 10])
+@pytest.mark.parametrize("overall", [True, False])
 @pytest.mark.parametrize("method", ["spearman", "pearson"])
-def test_ccpred(predictions_mtz, method, bins):
+def test_ccpred(predictions_mtz, method, bins, overall):
     tf = TemporaryDirectory()
     csv = f"{tf.name}/out.csv"
-    command = f"-o {csv} -b {bins} {predictions_mtz}"
+    command = f"-o {csv} -b {bins} "
+    if overall:
+        command = command + ' --overall '
+    command = command + f" {predictions_mtz}"
 
     parser = ccpred.ArgumentParser().parse_args(command.split())
 
     assert not exists(csv)
-    ccpred.run_analysis(parser, show=False)
+    ccpred.run_analysis(parser)
     assert exists(csv)
 
     df = pd.read_csv(csv)

--- a/tests/stats/test_cc.py
+++ b/tests/stats/test_cc.py
@@ -60,13 +60,18 @@ def test_ccanom(xval_mtz, method, bins):
 @pytest.mark.parametrize("bins", [1, 10])
 @pytest.mark.parametrize("overall", [True, False])
 @pytest.mark.parametrize("method", ["spearman", "pearson"])
-def test_ccpred(predictions_mtz, method, bins, overall):
+@pytest.mark.parametrize("multi", [False, True])
+def test_ccpred(predictions_mtz, method, bins, overall, multi):
     tf = TemporaryDirectory()
     csv = f"{tf.name}/out.csv"
     command = f"-o {csv} -b {bins} "
     if overall:
         command = command + ' --overall '
-    command = command + f" {predictions_mtz}"
+    command = command + f" {predictions_mtz} "
+
+    if multi:
+        command = command + f" {predictions_mtz} "
+        command = command + f" {predictions_mtz} "
 
     parser = ccpred.ArgumentParser().parse_args(command.split())
 
@@ -75,5 +80,9 @@ def test_ccpred(predictions_mtz, method, bins, overall):
     assert exists(csv)
 
     df = pd.read_csv(csv)
-    assert len(df) == 2*bins + 1
+
+    if multi and not overall:
+        assert len(df) == 6*bins + 1
+    else:
+        assert len(df) == 2*bins + 1
 


### PR DESCRIPTION
This adds an `--overall` flag to `careless.ccpred` which computes ccpred across all input mtzs rather than independently for each file. 