### PR TITLE
Uncertainty keys

### DIFF
--- a/careless/args/interpretation.py
+++ b/careless/args/interpretation.py
@@ -27,6 +27,15 @@ args_and_kwargs = (
         "default" : None,
     }),
 
+    (("--uncertainty-key", ),  {
+        "help":"What key to use for reflection error estimates. "
+               "If no key is given, careless will first check for a key beginning with 'SIG' or 'Sig' "
+               "which matches the intensity key (e.g. Iobs -> SigIobs). "
+               "Failing that, careless will ust first key with the StdDev dtype.",
+        "type":str, 
+        "default" : None,
+    }),
+
     (("--anomalous",), { 
         "help":f"If this flag is supplied, Friedel mates will be kept separate.", 
         "action":'store_true', 

--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -288,11 +288,9 @@ class MonoFormatter(DataFormatter):
                 for k in ds:
                     if k == prefix + intensity_key:
                         uncertainty_key = k
-        # TODO: this is a temporary fix for an older version of the crystfel parser
-        # please remove this upon the next rs release (2021-09-10)
         if uncertainty_key is None:
-            if 'sigmaI' in ds:
-                uncertainty_key = 'sigmaI'
+            uncertainty_key = get_first_key_of_dtype(ds, 'Q')
+
 
         if uncertainty_key is None:
             raise ValueError(
@@ -536,11 +534,8 @@ class LaueFormatter(DataFormatter):
                 for k in ds:
                     if k == prefix + intensity_key:
                         uncertainty_key = k
-        # TODO: this is a temporary fix for an older version of the crystfel parser
-        # please remove this upon the next rs release (2021-09-10)
         if uncertainty_key is None:
-            if 'sigmaI' in ds:
-                uncertainty_key = 'sigmaI'
+            uncertainty_key = get_first_key_of_dtype(ds, 'Q')
 
         if uncertainty_key is None:
             raise ValueError(

--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -211,7 +211,7 @@ class MonoFormatter(DataFormatter):
 
         return cls(
             parser.intensity_key,
-            None, #<-- uncertainty key has to match {SIG,Sig}intensity_key
+            parser.uncertainty_key,
             parser.image_key,
             parser.metadata_keys.split(','),
             parser.separate_files,
@@ -443,7 +443,7 @@ class LaueFormatter(DataFormatter):
         return cls(
             parser.wavelength_key,
             parser.intensity_key,
-            None, #<-- uncertainty key has to match {SIG,Sig}intensity_key
+            parser.uncertainty_key,
             parser.image_key,
             parser.metadata_keys.split(','),
             parser.separate_files,


### PR DESCRIPTION
- Improve careless UX by making it automatically fallback to the first sigma key. 
- Make it possible to override the uncertainty key with `--uncertainty-key`.