### PR TITLE
add scale moments to predictions

### DIFF
--- a/careless/io/manager.py
+++ b/careless/io/manager.py
@@ -105,6 +105,7 @@ class DataManager():
         asu_id,H = self.asu_collection.to_asu_id_and_miller_index(refl_id)
         #ipred = model(inputs)
         ipred,sigipred = model.prediction_mean_stddev(inputs)
+        scale,sigscale = model.prediction_mean_stddev(inputs)
 
         h,k,l = H.T
         results = ()
@@ -119,6 +120,8 @@ class DataManager():
                 'SigIobs' : sig_iobs[idx],
                 'Ipred' : ipred[idx],
                 'SigIpred' : sigipred[idx],
+                'Scale' : scale[idx],
+                'SigScale' : sigscale[idx],
                 }, 
                 cell=asu.cell, 
                 spacegroup=asu.spacegroup,


### PR DESCRIPTION
It is potentially helpful to include estimates of the first and second moments of the scale distribution predicted for each reflection observation. This PR will add that info to the `*_predictions_#.mtz` files. 