### PR TITLE
add cli parameter --kl-weight

### DIFF
--- a/careless/args/prior.py
+++ b/careless/args/prior.py
@@ -4,6 +4,13 @@ Options related to the prior distribution applied to the structure factors durin
 """
 
 args_and_kwargs = (
+    (("--kl-weight",), {
+        "help": "Set the weight of the kl divergence term relative to the likliehood. "
+                "By default, by default this is based purely on the number of reflections.",
+        "type": float, 
+        "default": None,
+    }),
+
     (("--wilson-prior-b",), {
         "help": "This flag enables learning reflections on a particular Wilson scale. "
                 "By default, the Wilson prior is flat across resolution bins. ",

--- a/careless/io/manager.py
+++ b/careless/io/manager.py
@@ -449,7 +449,7 @@ class DataManager():
                     scaling_model = mlp_scaler
 
         from tensorflow_probability import distributions as tfd
-        model = VariationalMergingModel(surrogate_posterior, prior, likelihood, scaling_model, parser.mc_samples)
+        model = VariationalMergingModel(surrogate_posterior, prior, likelihood, scaling_model, parser.mc_samples, kl_weight=parser.kl_weight)
 
         opt = tf.keras.optimizers.Adam(
             parser.learning_rate,


### PR DESCRIPTION
The ability to use mean reduction with a weighted kl divergence has been available at the api level for a long time now. This pr just adds a new command line argument `--kl-weight=` to enable users to access this feature. 