### PR TITLE
fix order of chained bijector

### DIFF
--- a/careless/models/merging/surrogate_posteriors.py
+++ b/careless/models/merging/surrogate_posteriors.py
@@ -123,8 +123,8 @@ class TruncatedNormal(SurrogatePosterior):
         scale = tfp.util.TransformedVariable(
             scale,
             tfb.Chain([
-                tfb.Exp(),
                 tfb.Shift(scale_shift),
+                tfb.Exp(),
             ]),
         )
         return cls(loc, scale, low, high)


### PR DESCRIPTION
tfb.Chain applies bijectors from right to left. When it comes to the scale parameter of the truncated normal posteriors, the shift was being applied before the exp. 