### PR TITLE
fix TypeError from DataSeries.reset_index

### DIFF
--- a/careless/stats/ccanom.py
+++ b/careless/stats/ccanom.py
@@ -106,7 +106,8 @@ def run_analysis(args):
         ccfunc = spearman_ccfunc
     elif args.method.lower() == "pearson":
         ccfunc = weighted_pearson_ccfunc
-    result = grouper.apply(ccfunc).reset_index(name='CCanom')
+    result = grouper.apply(ccfunc)
+    result = rs.DataSet({"CCanom" : result}).reset_index()
     result['Resolution Range (Å)'] = np.array(labels)[result.bin]
     result['Spacegroup'] = grouper['Spacegroup'].apply('first').to_numpy()
     if not args.overall:

--- a/careless/stats/cchalf.py
+++ b/careless/stats/cchalf.py
@@ -101,7 +101,8 @@ def run_analysis(args):
         ccfunc = spearman_ccfunc
     elif args.method.lower() == "pearson":
         ccfunc = weighted_pearson_ccfunc
-    result = grouper.apply(ccfunc).reset_index(name='CChalf')
+    result = grouper.apply(ccfunc)
+    result = rs.DataSet({"CChalf" : result}).reset_index()
     result['Resolution Range (Å)'] = np.array(labels)[result.bin]
     result['Spacegroup'] = grouper['Spacegroup'].apply('first').to_numpy()
     if not args.overall:

--- a/careless/stats/ccpred.py
+++ b/careless/stats/ccpred.py
@@ -90,7 +90,8 @@ def run_analysis(args):
     elif args.method.lower() == "pearson":
         ccfunc = weighted_pearson_ccfunc
 
-    result = grouper.apply(ccfunc).reset_index(name='CCpred')
+    result = grouper.apply(ccfunc)
+    result = rs.DataSet({"CCpred" : result}).reset_index()
     result['Resolution Range (Å)'] = np.array(labels)[result.bin]
     result['Spacegroup'] = grouper['Spacegroup'].apply('first').to_numpy()
     if not args.overall:

--- a/careless/stats/filter_by_image_cc.py
+++ b/careless/stats/filter_by_image_cc.py
@@ -99,7 +99,8 @@ def run_analysis(args):
     elif args.method.lower() == "pearson":
         ccfunc = weighted_pearson_ccfunc
 
-    result = grouper.apply(ccfunc).reset_index(name='CCpred')
+    result = grouper.apply(ccfunc)
+    result = rs.DataSet({"CCpred" : result}).reset_index()
     result['file_id'] = grouper.first()['file_id'].to_numpy()
     result['asu_id'] = grouper.first()['asu_id'].to_numpy()
     result = result[['file', 'file_id', 'asu_id', 'image_id', 'CCpred']]

--- a/careless/stats/image_cc.py
+++ b/careless/stats/image_cc.py
@@ -76,7 +76,8 @@ def run_analysis(args):
     elif args.method.lower() == "pearson":
         ccfunc = weighted_pearson_ccfunc
 
-    result = grouper.apply(ccfunc).reset_index(name='CCpred')
+    result = grouper.apply(ccfunc)
+    result = rs.DataSet({"CCpred" : result}).reset_index()
     result['file_id'] = grouper.first()['file_id'].to_numpy()
     result['asu_id'] = grouper.first()['asu_id'].to_numpy()
     result = result[['file', 'file_id', 'asu_id', 'BATCH', 'CCpred']]

--- a/careless/stats/rsplit.py
+++ b/careless/stats/rsplit.py
@@ -84,7 +84,8 @@ def run_analysis(args):
         grouper = ds.groupby(["bin", "repeat"])
     else:
         grouper = ds.groupby(["file", "bin", "repeat"])
-    result = grouper.apply(rsplit).reset_index(name='Rsplit')
+    result = grouper.apply(rsplit)
+    result = rs.DataSet({"Rsplit" : result}).reset_index()
     result['Resolution Range (Å)'] = np.array(labels)[result.bin]
     result['Spacegroup'] = grouper['Spacegroup'].apply('first').to_numpy()
     if not args.overall:


### PR DESCRIPTION
An issue in `reciprocalspaceship` (https://github.com/rs-station/reciprocalspaceship/issues/223) is causing multiple failures in the `careless` stats module (#133). This is a workaround which fixes the issue by removing calls to `rs.DataSeries.reset_index` and replacing them with `rs.DataSet.reset_index`. 