### PR TITLE
use multiprocessing to bypass tf mem leak

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
 source = careless 
+concurrency = multiprocessing


### PR DESCRIPTION
This PR addresses a [memory leak in tensorflow](https://github.com/tensorflow/tensorflow/issues/36465) which was causing CLI to fail on the default GitHub runner which has 7GB of memory currently. I'm using the multiprocessing trick referenced in the tf issue to force tf to clean up its memory at the end of each test in `tests/test_cli.py`. 

This PR supersedes #139 as it is a cleaner solution which does not break codecov. 