### PR TITLE
Update stream file doc, change mlp-width default to 10

### DIFF
--- a/careless/args/required.py
+++ b/careless/args/required.py
@@ -4,15 +4,22 @@ description = None
 args_and_kwargs = (
     # Required args
     (("metadata_keys", ),  {
-        "help":"Metadata keys for scaling. This is expected to be a comma delimitted string",
+        "help":"Metadata keys for scaling. This is expected to be a comma delimitted string. "
+               "You may use `rs.mtzdump` to check the available metadata column names in mtz files. "
+               "Careless always provides the special metadata keys, "
+               "'dHKL,Hobs,Kobs,Lobs,image_id'. "
+               "For stream files, careless does not support arbitrary metadata columns but rather "
+               "provides the metadata keys, "
+               "'BATCH,s1x,s1y,s1z,ewald_offset,angular_ewald_offset', "
+               "These correspond to image number, scattered beam wavevectors (x,y,z), and ewald offsets (inverse angstroms, degrees).",
         "type":str, 
     }),
 
     (("reflection_files", ), { 
         "metavar":"reflections.{mtz,stream}", 
-        "help":"Mtz or stream file(s) containing unmerged reflection observations. If you are supplying"
-               " stream files, you must also use the --spacegroups option to supply the symmetry for "
-               "merging.", 
+        "help":"Mtz or stream file(s) containing unmerged reflection observations. "
+               "If you are supplying stream files, you must also use the --spacegroups option to supply the symmetry for merging. "
+               "See the metadata_keys param for more info about stream file usage.",
         "type":str, 
         "nargs":'+',
     }),

--- a/careless/args/scaling.py
+++ b/careless/args/scaling.py
@@ -25,9 +25,9 @@ args_and_kwargs = (
     }),
 
     (("--mlp-width",), {
-        "help": "The width of the hidden layers of the neural net. This defaults to the dimensionality of the metadata array.",
+        "help": "The width of the hidden layers of the neural net. The default is 10.",
         "type": int,
-        "default": None,
+        "default": 10,
     }),
 
     (("--image-layers",), {


### PR DESCRIPTION
This is a very straightforward PR. I added a little more description about the metadata available for stream files in the CLI. I also am changing the default `--mlp-width` to be 10 rather than inferred from the metadata width. 

This resolves #141  and #142 