### PR TITLE
disable dm output by default

### DIFF
--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -52,4 +52,11 @@ args_and_kwargs = (
         "action" : "store_true",
         "default" : False,
     }),
+
+    (("--save-data-manager", ),  {
+        "help":"Optionally save the data manager object in pickle format.",
+        "action" : "store_true",
+        "default" : False,
+    }),
+    
 )

--- a/careless/careless.py
+++ b/careless/careless.py
@@ -68,9 +68,10 @@ def run_careless(parser):
 
     model.surrogate_posterior.save_weights(parser.output_base + '_structure_factor')
     model.scaling_model.save_weights(parser.output_base + '_scale')
-    import pickle
-    with open(parser.output_base + "_data_manager.pickle", "wb") as out:
-        pickle.dump(dm, out)
+    if parser.save_data_manager:
+        import pickle
+        with open(parser.output_base + "_data_manager.pickle", "wb") as out:
+            pickle.dump(dm, out)
 
     predictions_data = None
     if test is not None:


### PR DESCRIPTION
This PR disables saving the data manager. It adds a CLI option, `--save-data-manager` to revert the behavior. 