### PR TITLE
update to tensorflow 2.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .
-        pip install "pytest<8"
     
     - name: Test with pytest
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     # Skip CI if 'skip ci' is contained in latest commit message
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/careless/args/tf_options.py
+++ b/careless/args/tf_options.py
@@ -8,6 +8,18 @@ args_and_kwargs = (
         "default":False,
     }),
 
+    (("--jit-compile",), {
+        "help":"Use jit compilation. By default defer to TF to decide.", 
+        "action":'store_true', 
+        "default":None,
+    }),
+
+    (("--reduce-retracing",), {
+        "help":"Use the reduce retracing option during compilation. By default defer to TF to decide.", 
+        "action":'store_true', 
+        "default": False,
+    }),
+
     (("--disable-gpu",), {
         "help":"Disable GPU for high memory models.", 
         "action":'store_true', 

--- a/careless/args/tf_options.py
+++ b/careless/args/tf_options.py
@@ -9,13 +9,13 @@ args_and_kwargs = (
     }),
 
     (("--jit-compile",), {
-        "help":"Use jit compilation. By default defer to TF to decide.", 
+        "help":"Use jit compilation. By default defer to TF to decide. Enabling this option may decrease memory requirements for some models at the expense of increasing startup time.", 
         "action":'store_true', 
         "default":None,
     }),
 
     (("--reduce-retracing",), {
-        "help":"Use the reduce retracing option during compilation. By default defer to TF to decide.", 
+        "help":"Use the reduce retracing option during compilation. This is disabled by default.", 
         "action":'store_true', 
         "default": False,
     }),

--- a/careless/careless.py
+++ b/careless/careless.py
@@ -57,6 +57,8 @@ def run_careless(parser):
         validation_data=test,
         validation_frequency=validation_frequency,
         progress=progress,
+        reduce_retracing=parser.reduce_retracing,
+        jit_compile=parser.jit_compile,
     )
 
     for i,ds in enumerate(dm.get_results(model.surrogate_posterior, inputs=train)):
@@ -101,6 +103,8 @@ def run_careless(parser):
                     parser.iterations,
                     message=f"Merging repeat {repeat+1} half {half_id+1}",
                     progress=progress,
+                    reduce_retracing=parser.reduce_retracing,
+                    jit_compile=parser.jit_compile,
                 )
 
                 for file_id,ds in enumerate(dm.get_results(model.surrogate_posterior, inputs=half)):

--- a/careless/io/manager.py
+++ b/careless/io/manager.py
@@ -1,5 +1,6 @@
 import numpy as np
 import tensorflow as tf
+import tf_keras as tfk
 import reciprocalspaceship as rs
 from .asu import ReciprocalASU,ReciprocalASUCollection
 from careless.models.base import BaseModel
@@ -453,7 +454,7 @@ class DataManager():
         from tensorflow_probability import distributions as tfd
         model = VariationalMergingModel(surrogate_posterior, prior, likelihood, scaling_model, parser.mc_samples, kl_weight=parser.kl_weight)
 
-        opt = tf.keras.optimizers.Adam(
+        opt = tfk.optimizers.Adam(
             parser.learning_rate,
             parser.beta_1,
             parser.beta_2,

--- a/careless/models/base.py
+++ b/careless/models/base.py
@@ -1,5 +1,5 @@
 import tensorflow as tf
-from tensorflow import keras as tfk
+import tf_keras as tfk
 import numpy as np
 
 

--- a/careless/models/likelihoods/mono.py
+++ b/careless/models/likelihoods/mono.py
@@ -1,4 +1,5 @@
 from careless.models.likelihoods.base import Likelihood
+import tf_keras as tfk
 import tensorflow as tf
 from tensorflow_probability import distributions as tfd
 from tensorflow_probability import util as tfu
@@ -76,18 +77,18 @@ class NeuralLikelihood(Likelihood):
 
         layers = []
         for _ in range(mlp_layers):
-            layer = tf.keras.layers.Dense(
+            layer = tfk.layers.Dense(
                 mlp_width,
-                activation=tf.keras.layers.LeakyReLU(),
+                activation=tfk.layers.LeakyReLU(),
             )
             layers.append(layer)
 
-        layer = tf.keras.layers.Dense(
+        layer = tfk.layers.Dense(
             1,
             activation='softplus',
         )
         layers.append(layer)
-        self.network = tf.keras.models.Sequential(layers)
+        self.network = tfk.models.Sequential(layers)
 
     def base_dist(self, loc, scale):
         raise NotImplementedError("extensions of this class must implement a base_dist(loc, scale) method")

--- a/careless/models/merging/surrogate_posteriors.py
+++ b/careless/models/merging/surrogate_posteriors.py
@@ -5,12 +5,13 @@ from tensorflow_probability import distributions as tfd
 from tensorflow_probability import bijectors as tfb
 from tensorflow_probability.python.internal import tensor_util
 import tensorflow as tf
+import tf_keras as tfk
 import numpy as np
 
-class SurrogatePosterior(tf.keras.models.Model):
+class SurrogatePosterior(tfk.models.Model):
     """ The base class for learnable variational distributions over structure factor amplitudes. """
     def __init__(self, distribution, **kwargs):
-        super().__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.distribution = distribution
 
     def sample(self, *args, **kwargs):

--- a/careless/models/merging/variational.py
+++ b/careless/models/merging/variational.py
@@ -192,12 +192,11 @@ class VariationalMergingModel(tfk.models.Model, BaseModel):
         else:
             x = data[0]
         y = self.get_intensities(x)
-        #x, y, sample_weight = data_adapter.unpack_x_y_sample_weight(data)
+
         # Run forward pass.
         with tf.GradientTape() as tape:
             y_pred = self(x, training=True)
-            #loss = self.compiled_loss(y, y_pred, sample_weight, regularization_losses=self.losses)
-            loss = self.compiled_loss(x, y, regularization_losses=self.losses)
+            loss = self.compiled_loss(y, y_pred, regularization_losses=self.losses)
 
         # Run backwards pass.
         grads = tape.gradient(loss, self.trainable_variables)
@@ -209,8 +208,8 @@ class VariationalMergingModel(tfk.models.Model, BaseModel):
         grads = [tf.where(tf.math.is_finite(g), g, 0.) for g in grads]
         self.optimizer.apply_gradients(zip(grads, self.trainable_variables))
 
-        #self.compiled_metrics.update_state(y, y_pred, sample_weight)
         self.compiled_metrics.update_state(y, y_pred)
+
         # Collect metrics to return
         return_metrics = {
             "Grad Norm" : grad_norm,

--- a/careless/models/merging/variational.py
+++ b/careless/models/merging/variational.py
@@ -1,15 +1,14 @@
 from careless.models.base import BaseModel
 from careless.utils.shame import sanitize_tensor
 from careless.models.merging.surrogate_posteriors import TruncatedNormal
-from tensorflow.python.keras.engine import data_adapter
+import tf_keras as tfk
 from tqdm.autonotebook import tqdm
 import tensorflow_probability as tfp
 import tensorflow as tf
-from tensorflow import keras as tfk
 import numpy as np
 
 
-class VariationalMergingModel(tfk.Model, BaseModel):
+class VariationalMergingModel(tfk.models.Model, BaseModel):
     """
     Merge data with a posterior parameterized by a surrogate distribution.
     """
@@ -188,12 +187,14 @@ class VariationalMergingModel(tfk.Model, BaseModel):
         Conduct a training step with `data`. This method is the same as tfk.Model.train_step except that it
         tracks the norm of the gradients as well. 
         """
-        data = data_adapter.expand_1d(data)
-        x, y, sample_weight = data_adapter.unpack_x_y_sample_weight(data)
+        x = data[0]
+        y = self.get_intensities(x)
+        #x, y, sample_weight = data_adapter.unpack_x_y_sample_weight(data)
         # Run forward pass.
         with tf.GradientTape() as tape:
             y_pred = self(x, training=True)
-            loss = self.compiled_loss(y, y_pred, sample_weight, regularization_losses=self.losses)
+            #loss = self.compiled_loss(y, y_pred, sample_weight, regularization_losses=self.losses)
+            loss = self.compiled_loss(x, y, regularization_losses=self.losses)
 
         # Run backwards pass.
         grads = tape.gradient(loss, self.trainable_variables)
@@ -205,7 +206,8 @@ class VariationalMergingModel(tfk.Model, BaseModel):
         if tf.math.is_finite(grad_norm):
             self.optimizer.apply_gradients(zip(grads, self.trainable_variables))
 
-        self.compiled_metrics.update_state(y, y_pred, sample_weight)
+        #self.compiled_metrics.update_state(y, y_pred, sample_weight)
+        self.compiled_metrics.update_state(y, y_pred)
         # Collect metrics to return
         return_metrics = {
             "Grad Norm" : grad_norm,

--- a/careless/models/merging/variational.py
+++ b/careless/models/merging/variational.py
@@ -221,7 +221,7 @@ class VariationalMergingModel(tfk.models.Model, BaseModel):
 
         return return_metrics
 
-    def train_model(self, data, steps, message=None, format_string="{:0.2e}", validation_data=None, validation_frequency=10, progress=True, use_custom_train_step=True):
+    def train_model(self, data, steps, message=None, format_string="{:0.2e}", validation_data=None, validation_frequency=10, progress=True, use_custom_train_step=True, jit_compile=None, reduce_retracing=False):
         """
         Alternative to the keras backed VariationalMergingModel.fit method. This method is much faster at the moment but less flexible.
         """
@@ -239,7 +239,7 @@ class VariationalMergingModel(tfk.models.Model, BaseModel):
                 return history
 
         if not self._run_eagerly:
-            train_step = tf.function(train_step, reduce_retracing=True)
+            train_step = tf.function(train_step, reduce_retracing=reduce_retracing, jit_compile=jit_compile)
 
         if validation_data is not None:
             val_scale = len(data[0]) / len(validation_data[0])

--- a/careless/models/scaling/base.py
+++ b/careless/models/scaling/base.py
@@ -1,5 +1,5 @@
 from careless.models.base import BaseModel
-from tensorflow import keras as tfk
+import tf_keras as tfk
 
 
 class Scaler(tfk.models.Model, BaseModel):

--- a/careless/models/scaling/image.py
+++ b/careless/models/scaling/image.py
@@ -1,4 +1,5 @@
 import tensorflow as tf
+import tf_keras as tfk
 from careless.models.base import BaseModel
 from careless.models.scaling.base import Scaler
 import tensorflow_probability as tfp
@@ -65,7 +66,7 @@ class HybridImageScaler(Scaler):
 class ImageLayer(Scaler):
     def __init__(self, units, max_images, activation=None, **kwargs):
         super().__init__(**kwargs)
-        self.activation = tf.keras.activations.get(activation)
+        self.activation = tfk.activations.get(activation)
         self.units = units
         self.max_images = max_images
 
@@ -101,7 +102,7 @@ class NeuralImageScaler(Scaler):
         if leakiness is None:
             activation = 'ReLU'
         else:
-            activation = tf.keras.layers.LeakyReLU(leakiness)
+            activation = tfk.layers.LeakyReLU(leakiness)
 
         for i in range(image_layers):
             layers.append(

--- a/careless/models/scaling/nn.py
+++ b/careless/models/scaling/nn.py
@@ -1,4 +1,5 @@
 import tensorflow as tf
+import tf_keras as tfk
 from tensorflow_probability import distributions as tfd
 from tensorflow_probability import bijectors as tfb
 import tensorflow_probability as tfp
@@ -6,7 +7,7 @@ from careless.models.scaling.base import Scaler
 import numpy as np
 
 
-class NormalLayer(tf.keras.layers.Layer):
+class NormalLayer(tfk.layers.Layer):
     def __init__(self, scale_bijector=None, epsilon=1e-7, **kwargs): 
         super().__init__(**kwargs)
         self.epsilon = epsilon
@@ -46,28 +47,27 @@ class MetadataScaler(Scaler):
 
         for i in range(n_layers):
             if leakiness is None:
-                activation = tf.keras.layers.ReLU()
+                activation = tfk.layers.ReLU()
             else:
-                activation = tf.keras.layers.LeakyReLU(leakiness)
-                #activation = tf.keras.activations.exponential
+                activation = tfk.layers.LeakyReLU(leakiness)
 
             mlp_layers.append(
-                tf.keras.layers.Dense(
+                tfk.layers.Dense(
                     width, 
                     activation=activation, 
                     use_bias=True, 
-                    kernel_initializer='identity'
+                    kernel_initializer='identity',
                     )
                 )
 
         #The last layer is linear and generates location/scale params
         tfp_layers = []
         tfp_layers.append(
-            tf.keras.layers.Dense(
+            tfk.layers.Dense(
                 2, 
                 activation='linear', 
                 use_bias=True, 
-                kernel_initializer='identity'
+                kernel_initializer='identity',
             )
         )
 
@@ -75,8 +75,8 @@ class MetadataScaler(Scaler):
         #tfp_layers.append(tfp.layers.IndependentNormal())
         tfp_layers.append(NormalLayer(epsilon=epsilon))
 
-        self.network = tf.keras.Sequential(mlp_layers)
-        self.distribution = tf.keras.Sequential(tfp_layers)
+        self.network = tfk.Sequential(mlp_layers)
+        self.distribution = tfk.Sequential(tfp_layers)
 
     def call(self, metadata):
         """

--- a/careless/parser.py
+++ b/careless/parser.py
@@ -10,6 +10,7 @@ class EnvironmentSettingsMixin(argparse.ArgumentParser):
         parser = super().parse_args(*args, **kwargs)
 
         from os import environ
+        environ["TF_USE_LEGACY_KERAS"] = "1" #use keras 2
         if parser.tf_debug:
             # This is very noisy
             environ['TF_CPP_MIN_LOG_LEVEL'] = "1"

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         "reciprocalspaceship>=0.9.16",
         "tqdm",
-        "tensorflow",
+        "tensorflow>=2.16",
         "tf_keras",
         "tensorflow-probability[tf]",
         "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,9 @@ setup(
     install_requires=[
         "reciprocalspaceship>=0.9.16",
         "tqdm",
-        "tensorflow<2.16",
-        "tensorflow-probability",
+        "tensorflow",
+        "tf_keras",
+        "tensorflow-probability[tf]",
         "matplotlib",
         "seaborn",
     ],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         "reciprocalspaceship>=0.9.16",
         "tqdm",
-        "tensorflow>=2.16",
+        "tensorflow",
         "tf_keras",
         "tensorflow-probability[tf]",
         "matplotlib",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import multiprocessing
 niter = 10
 # True will use multiprocessing to bypass the tf memory leak issue,
 # but it may result in less verbose error messages.
-use_mp = True
+use_mp = False
 eager=True
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,12 +9,16 @@ niter = 10
 # True will use multiprocessing to bypass the tf memory leak issue,
 # but it may result in less verbose error messages.
 use_mp = True
+eager=True
+
 
 def run_careless(parser):
     """
     Workaround for tensorflow memory leak.
     see: https://github.com/tensorflow/tensorflow/issues/36465
     """
+    if eager:
+        parser.run_eagerly=True
     if use_mp:
         proc = multiprocessing.Process(target=_run_careless, args=(parser,))
         proc.start()


### PR DESCRIPTION
[TensorFlow Probability 0.24.0](https://github.com/tensorflow/probability/releases/tag/v0.24.0) upgrades to TensorFlow version 2.16. From the release notes, a substantial change in distribution had to be made to allow this. The tf pypi package now ships with Keras version 3 which is a total rewrite to support other backends (PyTorch & JAX). This is a breaking change for the `tfp.layers` submodule. I think this is probably because Keras 3 enforces that layers return tensors and not abstract things like distributions. To mitigate this, `tfp` now ships a separate `tensorflow-probability[tfp]` pypi release which retains support for `tfp.layers`. This relies on the `tf_keras` package which is Keras 2. 

To support `tfp` v0.24.0, I had to make a number of changes. 
 - require `tensorflow-probability[tf]` rather than simple `tensorflow-probability`
 -  require tf_keras` 
 - remove any references to `tf.keras` from the code base 
 - `import tf_keras as tfk` wherever Keras is required
 - remove `tensorflow.python.keras.engine.data_adapter` from the training loop