### PR TITLE
Improve Numerical Stability

### DIFF
--- a/careless/args/scaling.py
+++ b/careless/args/scaling.py
@@ -43,4 +43,12 @@ args_and_kwargs = (
         "dest" : "use_image_scales",
         "default": True,
     }),
+
+    (("--scale-bijector",), {
+        "help": "What function to use to ensure positivity of the standard deviation of scales. "
+                "Supported functions are --scale-bijector=exp and the default is --scale-bijector=softplus",
+        "type": str,
+        "default": "softplus",
+        "choices" : ["exp", "softplus"],
+    }),
 )

--- a/careless/models/scaling/image.py
+++ b/careless/models/scaling/image.py
@@ -96,7 +96,7 @@ class ImageLayer(Scaler):
         return result
 
 class NeuralImageScaler(Scaler):
-    def __init__(self, image_layers, max_images, mlp_layers, mlp_width, leakiness=0.01, epsilon=1e-7):
+    def __init__(self, image_layers, max_images, mlp_layers, mlp_width, leakiness=0.01, epsilon=1e-7, scale_bijector=None):
         super().__init__()
         layers = []
         if leakiness is None:
@@ -111,15 +111,13 @@ class NeuralImageScaler(Scaler):
 
         self.image_layers = layers
         from careless.models.scaling.nn import MetadataScaler
-        self.metadata_scaler = MetadataScaler(mlp_layers, mlp_width, leakiness, epsilon=epsilon)
+        self.metadata_scaler = MetadataScaler(mlp_layers, mlp_width, leakiness, epsilon=epsilon, scale_bijector=scale_bijector)
 
     def call(self, inputs):
         result = self.get_metadata(inputs)
         image_id = self.get_image_id(inputs),
 
         result = self.metadata_scaler.network(result)
-        # One could use this line to add a skip connection here
-        #result = result + self.get_metadata(inputs)
 
         for layer in self.image_layers:
             result = layer((result, image_id))

--- a/careless/models/scaling/nn.py
+++ b/careless/models/scaling/nn.py
@@ -22,8 +22,6 @@ class NormalLayer(tfk.layers.Layer):
     def call(self, x, **kwargs):
         loc, scale = tf.unstack(x, axis=-1)
         scale = self.scale_bijector(scale)
-        loc = loc 
-        scale = scale 
         return tfd.Normal(loc, scale)
 
 class MetadataScaler(Scaler):

--- a/careless/models/scaling/nn.py
+++ b/careless/models/scaling/nn.py
@@ -14,7 +14,7 @@ class NormalLayer(tfk.layers.Layer):
         if scale_bijector is None:
             self.scale_bijector = tfb.Chain([
                 tfb.Shift(epsilon),
-                tfb.Exp(),
+                tfb.Softplus(),
             ])
         else:
             self.scale_bijector = scale_bijector
@@ -22,6 +22,8 @@ class NormalLayer(tfk.layers.Layer):
     def call(self, x, **kwargs):
         loc, scale = tf.unstack(x, axis=-1)
         scale = self.scale_bijector(scale)
+        loc = loc 
+        scale = scale 
         return tfd.Normal(loc, scale)
 
 class MetadataScaler(Scaler):

--- a/careless/models/scaling/nn.py
+++ b/careless/models/scaling/nn.py
@@ -29,7 +29,7 @@ class MetadataScaler(Scaler):
     Neural network based scaler with simple dense layers.
     This neural network outputs a normal distribution.
     """
-    def __init__(self, n_layers, width, leakiness=0.01, epsilon=1e-7):
+    def __init__(self, n_layers, width, leakiness=0.01, epsilon=1e-7, scale_bijector=None):
         """
         Parameters
         ----------
@@ -73,7 +73,7 @@ class MetadataScaler(Scaler):
 
         #The final layer converts the output to a Normal distribution
         #tfp_layers.append(tfp.layers.IndependentNormal())
-        tfp_layers.append(NormalLayer(epsilon=epsilon))
+        tfp_layers.append(NormalLayer(epsilon=epsilon, scale_bijector=scale_bijector))
 
         self.network = tfk.Sequential(mlp_layers)
         self.distribution = tfk.Sequential(tfp_layers)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,10 +170,30 @@ def test_freeze_scales(off_file):
 
 @pytest.mark.parametrize('clip_type', ['--clipvalue', '--clipnorm', '--global-clipnorm'])
 def test_clipping(off_file, clip_type):
-    """ Test `--freeze-scales` for execution """
+    """ Test gradient clipping settings """
     with TemporaryDirectory() as td:
         out = td + '/out'
         flags = f"mono --disable-gpu --iterations={niter} {clip_type}=1. dHKL,image_id"
+        command = flags +  f" {off_file} {out}"
+        from careless.parser import parser
+        parser = parser.parse_args(command.split())
+        run_careless(parser)
+
+        out_file = out + f"_0.mtz"
+        assert exists(out_file)
+
+
+@pytest.mark.parametrize('scale_bijector', ['exp', 'softplus'])
+@pytest.mark.parametrize('image_layers', [None, 2])
+def test_scale_bijector(off_file, scale_bijector, image_layers):
+    """ Test scale bijector settings """
+    with TemporaryDirectory() as td:
+        out = td + '/out'
+        if image_layers is not None:
+            flags = f"mono --disable-gpu --image-layers={image_layers} --iterations={niter} --scale-bijector={scale_bijector} dHKL,image_id"
+        else:
+            flags = f"mono --disable-gpu --iterations={niter} --scale-bijector={scale_bijector} dHKL,image_id"
+
         command = flags +  f" {off_file} {out}"
         from careless.parser import parser
         parser = parser.parse_args(command.split())


### PR DESCRIPTION
Several users have been reporting numerical issues with careless. Recently, I was able to reproduce them, and I tracked the issue down to an overflow in the [scale parameter](https://github.com/rs-station/careless/blob/e99fbd091e1e6291ae5fe625c89bdebc98d777e8/careless/models/scaling/nn.py#L24) of the normal distribution which parameterizes the reflection scales. The [default bijector](https://github.com/rs-station/careless/blob/e99fbd091e1e6291ae5fe625c89bdebc98d777e8/careless/models/scaling/nn.py#L17) here has been the exponential for sometime. However, apparently it does not work stably for some data sets (probably those with particularly bright reflections). One solution would be to normalize the intensities in the likelihood calculation. This might be worth exploring in the future. For now, I have changed the default bijector back to softplus and added a command line flag `--scale-bijector={exp,softplus}`. 