### PR TITLE
Consistent dmin

### DIFF
--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -77,12 +77,6 @@ class DataFormatter():
 
         cells,spacegroups = [],[]
         for file_id, ds in enumerate(datasets):
-            if not ds.cell.is_compatible_with_spacegroup(ds.spacegroup):
-                raise ValueError(
-                    f"Spacegroup {ds.spacegroup} found to be incompatible with unit cell constants {ds.cell} cannot proceed."
-                )
-            cells.append(ds.cell)
-            spacegroups.append(ds.spacegroup)
             sg = None
             if self.spacegroups is not None:
                 sg = self.spacegroups[file_id]
@@ -100,6 +94,13 @@ class DataFormatter():
                 data = ds
             else:
                 data = rs.concat((data, ds), check_isomorphous=False)
+
+            cells.append(ds.cell)
+            spacegroups.append(sg)
+            if not ds.cell.is_compatible_with_spacegroup(sg):
+                raise ValueError(
+                    f"Spacegroup {ds.spacegroup} found to be incompatible with unit cell constants {ds.cell} cannot proceed."
+                )
 
         reciprocal_asus = []
         if self.separate_outputs:

--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -77,6 +77,10 @@ class DataFormatter():
 
         cells,spacegroups = [],[]
         for file_id, ds in enumerate(datasets):
+            if not ds.cell.is_compatible_with_spacegroup(ds.spacegroup):
+                raise ValueError(
+                    f"Spacegroup {ds.spacegroup} found to be incompatible with unit cell constants {ds.cell} cannot proceed."
+                )
             cells.append(ds.cell)
             spacegroups.append(ds.spacegroup)
             sg = None

--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -75,7 +75,10 @@ class DataFormatter():
         """
         data = None
 
+        cells,spacegroups = [],[]
         for file_id, ds in enumerate(datasets):
+            cells.append(ds.cell)
+            spacegroups.append(ds.spacegroup)
             sg = None
             if self.spacegroups is not None:
                 sg = self.spacegroups[file_id]
@@ -96,10 +99,12 @@ class DataFormatter():
 
         reciprocal_asus = []
         if self.separate_outputs:
-            for ds in datasets:
-                reciprocal_asus.append(ReciprocalASU(ds.cell, ds.spacegroup, data.dHKL.min(), self.anomalous))
-        if len(reciprocal_asus) == 0:
-            reciprocal_asus.append(ReciprocalASU(data.cell, data.spacegroup, data.dHKL.min(), self.anomalous))
+            for cell,sg in zip(cells, spacegroups):
+                reciprocal_asus.append(
+                    ReciprocalASU(cell, sg, data.dHKL.min(), self.anomalous))
+        else:
+            reciprocal_asus.append(
+                ReciprocalASU(data.cell, data.spacegroup, data.dHKL.min(), self.anomalous))
 
         rac = ReciprocalASUCollection(reciprocal_asus)
         data['image_id'] = data.groupby(['file_id', 'image_id']).ngroup()

--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -107,13 +107,14 @@ class DataFormatter():
                 )
 
         reciprocal_asus = []
+        dmin = data.dHKL.min()
         if self.separate_outputs:
             for cell,sg in zip(cells, spacegroups):
                 reciprocal_asus.append(
-                    ReciprocalASU(cell, sg, data.dHKL.min(), self.anomalous))
+                    ReciprocalASU(cell, sg, dmin, self.anomalous))
         else:
             reciprocal_asus.append(
-                ReciprocalASU(data.cell, data.spacegroup, data.dHKL.min(), self.anomalous))
+                ReciprocalASU(data.cell, data.spacegroup, dmin, self.anomalous))
 
         rac = ReciprocalASUCollection(reciprocal_asus)
         data['image_id'] = data.groupby(['file_id', 'image_id']).ngroup()

--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -75,7 +75,6 @@ class DataFormatter():
         """
         data = None
 
-        reciprocal_asus = []
         for file_id, ds in enumerate(datasets):
             sg = None
             if self.spacegroups is not None:
@@ -84,7 +83,6 @@ class DataFormatter():
 
             if self.separate_outputs:
                 asu_id = file_id
-                reciprocal_asus.append(ReciprocalASU(ds.cell, ds.spacegroup, ds.dHKL.min(), self.anomalous))
             else:
                 asu_id = 0
 
@@ -96,6 +94,10 @@ class DataFormatter():
             else:
                 data = rs.concat((data, ds), check_isomorphous=False)
 
+        reciprocal_asus = []
+        if self.separate_outputs:
+            for ds in datasets:
+                reciprocal_asus.append(ReciprocalASU(ds.cell, ds.spacegroup, data.dHKL.min(), self.anomalous))
         if len(reciprocal_asus) == 0:
             reciprocal_asus.append(ReciprocalASU(data.cell, data.spacegroup, data.dHKL.min(), self.anomalous))
 

--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -77,9 +77,13 @@ class DataFormatter():
 
         cells,spacegroups = [],[]
         for file_id, ds in enumerate(datasets):
-            sg = None
             if self.spacegroups is not None:
                 sg = self.spacegroups[file_id]
+            elif ds.spacegroup is not None:
+                sg = ds.spacegroup
+            else:
+                raise ValueError("Could not determine spacegroups. Please supply the --spacegroups flag")
+
             ds = self.prep_dataset(ds, sg)
 
             if self.separate_outputs:


### PR DESCRIPTION
In the `--separate-files` mode, use the same dmin for every file. This ensures the double wilson prior will not throw an error due to a parent being outside the resolution range. 