### PR TITLE
Polystream

### DIFF
--- a/careless/args/required.py
+++ b/careless/args/required.py
@@ -19,7 +19,8 @@ args_and_kwargs = (
         "metavar":"reflections.{mtz,stream}", 
         "help":"Mtz or stream file(s) containing unmerged reflection observations. "
                "If you are supplying stream files, you must also use the --spacegroups option to supply the symmetry for merging. "
-               "See the metadata_keys param for more info about stream file usage.",
+               "See the metadata_keys param for more info about stream file usage. "
+               "careless poly does not currently support .stream files.",
         "type":str, 
         "nargs":'+',
     }),

--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -2,6 +2,7 @@ import numpy as np
 import tensorflow as tf
 import reciprocalspaceship as rs
 import gemmi
+from functools import wraps
 from .asu import ReciprocalASU,ReciprocalASUCollection
 from careless.models.base import BaseModel
 from careless.utils.positional_encoding import positional_encoding
@@ -630,4 +631,14 @@ class LaueFormatter(DataFormatter):
         }
 
         return self.pack_inputs(inputs), rac
+
+    @wraps(DataFormatter.format_files)
+    def format_files(self, files):
+        for file in files:
+            if file.endswith('.stream'):
+                raise ValueError(
+                    "careless poly does not support .stream files. Use careless mono instead."
+                )
+        return super().format_files(files)
+
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,6 +110,11 @@ def test_crystfel(stream_file):
     flags = f"mono --disable-gpu --iterations={niter} --spacegroups=1 dHKL,image_id"
     base_test_together(flags, [stream_file])
 
+    #Careless poly should fail with a clear error message
+    with pytest.raises(ValueError):
+        flags = f"poly --disable-gpu --iterations={niter} --spacegroups=1 dHKL,image_id"
+        base_test_together(flags, [stream_file])
+
 def test_scale_weight_save_and_load(off_file):
     """
     Test saving and loading weights. 


### PR DESCRIPTION
Print a clear error message when people try to run `careless poly` on a `.stream` file. 