### PR TITLE
Removed reset_index() call causing DataFrame indices to be plotted

### DIFF
--- a/careless/stats/completeness.py
+++ b/careless/stats/completeness.py
@@ -46,7 +46,7 @@ def run_analysis(args):
         print(results.to_string(index=False))
 
     ax = sns.lineplot(
-        data=results.reset_index().melt(xlabel),
+        data=results.melt(xlabel),
         x=xlabel,
         y='value',
         hue='variable',


### PR DESCRIPTION
Simple fix to deal with `careless.completeness` plotting the requested completeness and also the array indices involved. Examples of output below:

```
In [5]: results.reset_index().melt(xlabel)
Out[5]: 
   Resolution Range (Å)       variable      value
0               overall          index   0.000000
1          47.52 - 3.32          index   1.000000
2           3.32 - 2.62          index   2.000000
3           2.62 - 2.28          index   3.000000
4           2.28 - 2.07          index   4.000000
5           2.07 - 1.92          index   5.000000
6           1.92 - 1.80          index   6.000000
7           1.80 - 1.71          index   7.000000
8           1.71 - 1.63          index   8.000000
9           1.63 - 1.57          index   9.000000
10          1.57 - 1.50          index  10.000000
11              overall  non-anomalous   0.986750
12         47.52 - 3.32  non-anomalous   0.997331
13          3.32 - 2.62  non-anomalous   1.000000
14          2.62 - 2.28  non-anomalous   1.000000
15          2.28 - 2.07  non-anomalous   1.000000
16          2.07 - 1.92  non-anomalous   0.999546
17          1.92 - 1.80  non-anomalous   0.998642
18          1.80 - 1.71  non-anomalous   0.999095
19          1.71 - 1.63  non-anomalous   0.998198
20          1.63 - 1.57  non-anomalous   0.997815
21          1.57 - 1.50  non-anomalous   0.902456

In [6]: results.melt(xlabel)
Out[6]: 
   Resolution Range (Å)       variable     value
0               overall  non-anomalous  0.986750
1          47.52 - 3.32  non-anomalous  0.997331
2           3.32 - 2.62  non-anomalous  1.000000
3           2.62 - 2.28  non-anomalous  1.000000
4           2.28 - 2.07  non-anomalous  1.000000
5           2.07 - 1.92  non-anomalous  0.999546
6           1.92 - 1.80  non-anomalous  0.998642
7           1.80 - 1.71  non-anomalous  0.999095
8           1.71 - 1.63  non-anomalous  0.998198
9           1.63 - 1.57  non-anomalous  0.997815
10          1.57 - 1.50  non-anomalous  0.902456
```
![image](https://github.com/user-attachments/assets/290b6f2e-6e09-4aed-b321-dba7a861528b)
![image](https://github.com/user-attachments/assets/773c40fd-110e-4c31-9933-fe31031a9625)

