### PR TITLE
make cchalf use unweighted pearson

### DIFF
--- a/careless/stats/cchalf.py
+++ b/careless/stats/cchalf.py
@@ -26,9 +26,9 @@ class ArgumentParser(BaseParser):
             "-m",
             "--method",
             default="pearson",
-            choices=["spearman", "pearson"],
-            help="Method for computing correlation coefficient (spearman or pearson). "
-            "The Pearson CC uses maximum-likelihood weights. Pearson is the default.",
+            choices=["pearson", "spearman", "weighted"],
+            help="Method for computing correlation coefficient (pearson, spearman, or weighted). "
+            "The 'weighted' option uses a Pearson CC with maximum-likelihood weights. Pearson is the default.",
         )
 
         self.add_argument(
@@ -57,6 +57,9 @@ def weighted_pearson_ccfunc(df):
 
 def spearman_ccfunc(df):
     return df[['F1', 'F2']].corr(method='spearman')['F1']['F2']
+
+def pearson_ccfunc(df):
+    return df[['F1', 'F2']].corr(method='pearson')['F1']['F2']
 
 def make_halves_cchalf(mtz, bins=10):
     """Construct half-datasets for computing CChalf"""
@@ -100,6 +103,8 @@ def run_analysis(args):
     if args.method.lower() == "spearman":
         ccfunc = spearman_ccfunc
     elif args.method.lower() == "pearson":
+        ccfunc = pearson_ccfunc
+    elif args.method.lower() == "weighted":
         ccfunc = weighted_pearson_ccfunc
     result = grouper.apply(ccfunc)
     result = rs.DataSet({"CChalf" : result}).reset_index()

--- a/careless/stats/cchalf.py
+++ b/careless/stats/cchalf.py
@@ -106,6 +106,9 @@ def run_analysis(args):
         ccfunc = pearson_ccfunc
     elif args.method.lower() == "weighted":
         ccfunc = weighted_pearson_ccfunc
+    else:
+        raise ValueError(f"Unrecognized CC --method, {args.method}")
+
     result = grouper.apply(ccfunc)
     result = rs.DataSet({"CChalf" : result}).reset_index()
     result['Resolution Range (Å)'] = np.array(labels)[result.bin]

--- a/careless/stats/ccpred.py
+++ b/careless/stats/ccpred.py
@@ -29,10 +29,9 @@ class ArgumentParser(BaseParser):
         self.add_argument(
             "-m",
             "--method",
-            default="pearson",
-            choices=["pearson", "spearman"],
-            help="Method for computing correlation coefficient (spearman or pearson). "
-            "The Pearson CC uses maximum-likelihood weights. Pearson is the default.",
+            default="weighted",
+            choices=["weighted", "pearson", "spearman"],
+            help="Method for computing correlation coefficient (spearman or pearson). Weighted is the default.",
         )
 
         self.add_argument(
@@ -57,6 +56,9 @@ def weighted_pearson_ccfunc(df, iobs='Iobs', ipred='Ipred', sigiobs='SigIobs'):
 
 def spearman_ccfunc(df, iobs='Iobs', ipred='Ipred'):
     return df[[iobs, ipred]].corr(method='spearman')[iobs][ipred]
+
+def pearson_ccfunc(df, iobs='Iobs', ipred='Ipred'):
+    return df[[iobs, ipred]].corr(method='pearson')[iobs][ipred]
 
 def run_analysis(args):
     labels = None
@@ -88,7 +90,11 @@ def run_analysis(args):
     if args.method.lower() == "spearman":
         ccfunc = spearman_ccfunc
     elif args.method.lower() == "pearson":
+        ccfunc = pearson_ccfunc
+    elif args.method.lower() == "weighted":
         ccfunc = weighted_pearson_ccfunc
+    else:
+        raise ValueError(f"Unrecognized CC --method, {args.method}")
 
     result = grouper.apply(ccfunc)
     result = rs.DataSet({"CCpred" : result}).reset_index()

--- a/careless/stats/image_cc.py
+++ b/careless/stats/image_cc.py
@@ -29,10 +29,9 @@ class ArgumentParser(BaseParser):
         self.add_argument(
             "-m",
             "--method",
-            default="pearson",
-            choices=["pearson", "spearman"],
-            help="Method for computing correlation coefficient (spearman or pearson). "
-            "The Pearson CC uses maximum-likelihood weights. Pearson is the default.",
+            default="weighted",
+            choices=["weighted", "pearson", "spearman"],
+            help="Method for computing correlation coefficient (spearman or pearson). Weighted is the default.",
         )
 
         self.add_argument(
@@ -52,6 +51,9 @@ def weighted_pearson_ccfunc(df, iobs='Iobs', ipred='Ipred', sigiobs='SigIobs'):
     y = df[ipred].to_numpy('float32')
     w = np.reciprocal(np.square(df[sigiobs])).to_numpy('float32')
     return rs.utils.weighted_pearsonr(x, y, w)
+
+def pearson_ccfunc(df, iobs='Iobs', ipred='Ipred'):
+    return df[[iobs, ipred]].corr(method='pearson')[iobs][ipred]
 
 def spearman_ccfunc(df, iobs='Iobs', ipred='Ipred'):
     return df[[iobs, ipred]].corr(method='spearman')[iobs][ipred]
@@ -73,8 +75,12 @@ def run_analysis(args):
 
     if args.method.lower() == "spearman":
         ccfunc = spearman_ccfunc
-    elif args.method.lower() == "pearson":
+    elif args.method.lower() == "weighted":
         ccfunc = weighted_pearson_ccfunc
+    elif args.method.lower() == "pearson":
+        ccfunc = pearson_ccfunc
+    else:
+        raise ValueError(f"Unrecognized CC --method, {args.method}")
 
     result = grouper.apply(ccfunc)
     result = rs.DataSet({"CCpred" : result}).reset_index()

--- a/tests/stats/test_cc.py
+++ b/tests/stats/test_cc.py
@@ -29,7 +29,7 @@ def test_rsplit(xval_mtz, method, bins):
 
 
 @pytest.mark.parametrize("bins", [1, 5])
-@pytest.mark.parametrize("method", ["spearman", "pearson"])
+@pytest.mark.parametrize("method", ["spearman", "pearson", "weighted"])
 def test_cchalf(xval_mtz, method, bins):
     tf = TemporaryDirectory()
     csv = f"{tf.name}/out.csv"

--- a/tests/stats/test_cc.py
+++ b/tests/stats/test_cc.py
@@ -49,7 +49,7 @@ def test_cchalf(xval_mtz, method, bins):
 
 
 @pytest.mark.parametrize("bins", [1, 5])
-@pytest.mark.parametrize("method", ["spearman", "pearson"])
+@pytest.mark.parametrize("method", ["spearman", "pearson", "weighted"])
 def test_ccanom(xval_mtz, method, bins):
     tf = TemporaryDirectory()
     csv = f"{tf.name}/out.csv"
@@ -70,7 +70,7 @@ def test_ccanom(xval_mtz, method, bins):
 
 @pytest.mark.parametrize("bins", [1, 5])
 @pytest.mark.parametrize("overall", [True, False])
-@pytest.mark.parametrize("method", ["spearman", "pearson"])
+@pytest.mark.parametrize("method", ["spearman", "pearson", "weighted"])
 @pytest.mark.parametrize("multi", [False, True])
 def test_ccpred(predictions_mtz, method, bins, overall, multi):
     tf = TemporaryDirectory()
@@ -143,7 +143,7 @@ def test_isigi(predictions_mtz, method, bins, overall, multi):
         assert len(df) == 1*bins
 
 
-@pytest.mark.parametrize("method", ["spearman", "pearson"])
+@pytest.mark.parametrize("method", ["weighted", "spearman", "pearson"])
 @pytest.mark.parametrize("multi", [False, True])
 def test_image_cc(predictions_mtz, method, multi):
     tf = TemporaryDirectory()
@@ -171,7 +171,7 @@ def test_image_cc(predictions_mtz, method, multi):
 
     df = pd.read_csv(csv)
 
-@pytest.mark.parametrize("method", ["spearman", "pearson"])
+@pytest.mark.parametrize("method", ["weighted", "spearman", "pearson"])
 def test_filter_by_image_cc(predictions_mtz, method, off_file, on_file):
     tf = TemporaryDirectory()
     command = f" {predictions_mtz} {off_file} {on_file} -c 0.1 -o {tf.name}/out"


### PR DESCRIPTION
Following a [discussion](https://discourse.rs-station.org/t/pearson-vs-spearman-correlation-coefficients/63/6) with Kay Diederichs on the rs-station forum, careless should use the unweighted Pearson correlation coefficient for CChalf. I'm making this the default with an option to use a weighted variant. All CC stats CLI programs now will take 'weighted', 'pearson', or 'spearman' for the `--method` flag. The defaults are set as follows

 - cchalf : pearson
 - ccanom : weighted
 - ccpred : weighted
 - image_ccpred : weighted
 - filter_image : weighted