### PR TITLE
reformat problematic plotting

### DIFF
--- a/careless/stats/ccanom.py
+++ b/careless/stats/ccanom.py
@@ -140,7 +140,8 @@ def run_analysis(args):
     else:
         plot_kwargs['hue'] = 'file'
         plot_kwargs['palette'] = "Dark2"
-
+        
+    plt.figure(figsize=(args.width, args.height))
     sns.lineplot(**plot_kwargs)
  
     plt.xticks(range(args.bins), labels, rotation=45, ha="right", rotation_mode="anchor")

--- a/careless/stats/cchalf.py
+++ b/careless/stats/cchalf.py
@@ -137,6 +137,7 @@ def run_analysis(args):
         plot_kwargs['hue'] = 'file'
         plot_kwargs['palette'] = "Dark2"
 
+    plt.figure(figsize=(args.width, args.height))
     sns.lineplot(**plot_kwargs)
     plt.xticks(range(args.bins), labels, rotation=45, ha="right", rotation_mode="anchor")
     plt.ylabel(r"$\mathrm{CC_{1/2}}$ " + f"({args.method})")

--- a/careless/stats/ccpred.py
+++ b/careless/stats/ccpred.py
@@ -47,6 +47,18 @@ class ArgumentParser(BaseParser):
             action="store_true",
             help="Pool all prediction mtz files into a single calculation rather than treating each file individually.",
         )
+        
+        self.add_argument(
+            "--height",
+            default=6,
+            help="Height of the plot to make with default value 6 (inches)."
+        )
+
+        self.add_argument(
+            "--width",
+            default=6,
+            help="Width of the plot to make with default value 6 (inches)."
+        )
 
 def weighted_pearson_ccfunc(df, iobs='Iobs', ipred='Ipred', sigiobs='SigIobs'):
     x = df[iobs].to_numpy('float32')
@@ -114,24 +126,28 @@ def run_analysis(args):
     else:
         print(result.to_string())
 
+    
+
+
+
     plot_kwargs = {
         'data' : result,
         'x' : 'bin',
         'y' : 'CCpred',
         'style' : 'test',
     }
-
     if args.overall:
         plot_kwargs['color'] = 'k'
     else:
         plot_kwargs['hue'] = 'file'
         plot_kwargs['palette'] = "Dark2"
 
+    plt.figure(figsize=(args.width, args.height))
     sns.lineplot(**plot_kwargs)
 
     plt.xticks(range(args.bins), labels, rotation=45, ha="right", rotation_mode="anchor")
     plt.ylabel(r"$\mathrm{CC_{pred}}$ " + f"({args.method})")
-    plt.legend(loc="center left", bbox_to_anchor=(1, 0.5))
+    plt.legend(bbox_to_anchor=(0.5, 1.35), loc='upper center', borderaxespad=0)
     plt.xlabel("Resolution ($\mathrm{\AA}$)")
     plt.grid(which='both', axis='both', ls='dashdot')
     if args.ylim is not None:

--- a/careless/stats/ccpred.py
+++ b/careless/stats/ccpred.py
@@ -47,18 +47,6 @@ class ArgumentParser(BaseParser):
             action="store_true",
             help="Pool all prediction mtz files into a single calculation rather than treating each file individually.",
         )
-        
-        self.add_argument(
-            "--height",
-            default=6,
-            help="Height of the plot to make with default value 6 (inches)."
-        )
-
-        self.add_argument(
-            "--width",
-            default=6,
-            help="Width of the plot to make with default value 6 (inches)."
-        )
 
 def weighted_pearson_ccfunc(df, iobs='Iobs', ipred='Ipred', sigiobs='SigIobs'):
     x = df[iobs].to_numpy('float32')
@@ -161,6 +149,7 @@ def run_analysis(args):
         plt.show()
 
 def main():
+    print("running main")
     parser = ArgumentParser().parse_args()
     run_analysis(parser)
 

--- a/careless/stats/completeness.py
+++ b/careless/stats/completeness.py
@@ -45,6 +45,7 @@ def run_analysis(args):
     else:
         print(results.to_string(index=False))
 
+    plt.figure(figsize=(args.width, args.height))
     ax = sns.lineplot(
         data=results.melt(xlabel),
         x=xlabel,

--- a/careless/stats/image_cc.py
+++ b/careless/stats/image_cc.py
@@ -36,13 +36,13 @@ class ArgumentParser(BaseParser):
 
         self.add_argument(
             "--height",
-            default=3,
+            default=6,
             help="Height of the plot to make with default value 3 (inches)."
         )
 
         self.add_argument(
             "--width",
-            default=7,
+            default=6,
             help="Width of the plot to make with default value 7 (inches)."
         )
 
@@ -93,7 +93,6 @@ def run_analysis(args):
     else:
         print(result.to_string())
 
-
     plot_kwargs = {
         'data' : result,
         'x' : 'BATCH',
@@ -102,13 +101,14 @@ def run_analysis(args):
         'marker' : '.',
         'linestyle' : 'none',
         'palette' : "Dark2",
+        'markeredgecolor' : 'none',
     }
 
     plt.figure(figsize=(args.width, args.height))
     sns.lineplot(**plot_kwargs)
 
     plt.ylabel(r"$\mathrm{CC_{pred}}$ " + f"({args.method})")
-    plt.legend(loc="center left", bbox_to_anchor=(1, 0.5))
+    plt.legend(bbox_to_anchor=(0.5, 1.35), loc='upper center', borderaxespad=0)
     plt.grid(which='both', axis='both', ls='dashdot')
     if args.ylim is not None:
         plt.ylim(args.ylim)

--- a/careless/stats/image_cc.py
+++ b/careless/stats/image_cc.py
@@ -34,18 +34,6 @@ class ArgumentParser(BaseParser):
             help="Method for computing correlation coefficient (spearman or pearson). Weighted is the default.",
         )
 
-        self.add_argument(
-            "--height",
-            default=6,
-            help="Height of the plot to make with default value 3 (inches)."
-        )
-
-        self.add_argument(
-            "--width",
-            default=6,
-            help="Width of the plot to make with default value 7 (inches)."
-        )
-
 def weighted_pearson_ccfunc(df, iobs='Iobs', ipred='Ipred', sigiobs='SigIobs'):
     x = df[iobs].to_numpy('float32')
     y = df[ipred].to_numpy('float32')

--- a/careless/stats/isigi.py
+++ b/careless/stats/isigi.py
@@ -121,6 +121,7 @@ def run_analysis(args):
         plot_kwargs['hue'] = 'file'
         plot_kwargs['palette'] = "Dark2"
 
+    plt.figure(figsize=(args.width, args.height))
     ax=sns.lineplot(**plot_kwargs)
     if args.log:
         ax.set(yscale='log')

--- a/careless/stats/parser.py
+++ b/careless/stats/parser.py
@@ -53,3 +53,17 @@ class BaseParser(argparse.ArgumentParser):
             help="Override the y-axis limits like `--ylim 0. 1.`"
         )
 
+        self.add_argument(
+            "--height",
+            default=6,
+             type=float,
+            help="Height of the plot to make with default value 6 (inches)."
+        )
+
+        self.add_argument(
+            "--width",
+            default=6,
+             type=float,
+            help="Width of the plot to make with default value 6 (inches)."
+        )
+            

--- a/careless/stats/rsplit.py
+++ b/careless/stats/rsplit.py
@@ -112,6 +112,7 @@ def run_analysis(args):
         plot_kwargs['hue'] = 'file'
         plot_kwargs['palette'] = "Dark2"
 
+    plt.figure(figsize=(args.width, args.height))
     sns.lineplot(**plot_kwargs)
     plt.xticks(range(args.bins), labels, rotation=45, ha="right", rotation_mode="anchor")
     plt.ylabel(r"$R_{\mathrm{split}}$")

--- a/careless/stats/rsplit.py
+++ b/careless/stats/rsplit.py
@@ -116,6 +116,7 @@ def run_analysis(args):
     plt.xticks(range(args.bins), labels, rotation=45, ha="right", rotation_mode="anchor")
     plt.ylabel(r"$R_{\mathrm{split}}$")
     plt.xlabel("Resolution ($\mathrm{\AA}$)")
+    plt.legend(loc='upper left', borderaxespad=0)
     plt.grid(which='both', axis='both', ls='dashdot')
     plt.tight_layout()
     if args.ylim is not None:


### PR DESCRIPTION
forced the legends above plots for `ccpred.py` and image_cc.py and changed default height and width of each plot. Added height and width arguments for `ccpred.py`.  Forced legends to the upper left for `rsplit.py`. 