### PR TITLE
Support Python 3.13

### DIFF
--- a/careless/__init__.py
+++ b/careless/__init__.py
@@ -10,7 +10,8 @@ def getVersionNumber():
 
     from setuptools.version import metadata
 
-    version = metadata.version("careless")
+    try:
+        version = metadata.version("careless")
     except ImportError:
         from setuptools.version import pkg_resources
 

--- a/careless/__init__.py
+++ b/careless/__init__.py
@@ -2,9 +2,15 @@
 def getVersionNumber():
     version = None
     try:
-        from setuptools.version import metadata
+        from importlib.metadata import version, PackageNotFoundError
+        __version__ = version("package-name")
+        return __version__
+    except:
+        pass
 
-        version = metadata.version("careless")
+    from setuptools.version import metadata
+
+    version = metadata.version("careless")
     except ImportError:
         from setuptools.version import pkg_resources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ authors=[
 description = "Merging crystallography data without much physics."
 readme = "README.md"
 dynamic = ["version"]
-requires-python = ">= 3.9,<3.13"
+requires-python = ">= 3.9,<=3.13"
 dependencies = [
     "reciprocalspaceship>=0.9.16",
     "tqdm",
-    "tensorflow-probability[tf]==0.25",
-    "tensorflow==2.18.0",
+    "tensorflow-probability[tf]>=0.25",
+    "tensorflow>=2.18.0",
     "matplotlib",
     "seaborn",
     "ray",
@@ -30,7 +30,7 @@ dev = [
     "pytest-xdist",
 ]
 cuda = [
-    "tensorflow[and-cuda]==2.18.0",
+    "tensorflow[and-cuda]>=2.18.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
- Add support for Python 3.13, and use current versioning API (`importlib` instead of `setuptools`)

```
Traceback (most recent call last):
  File "/home/xvg/subhkl-examples/.venv/bin/careless", line 4, in <module>
    from careless.careless import main
  File "/home/xvg/subhkl-examples/.venv/lib/python3.13/site-packages/careless/__init__.py", line 9, in <module>
    __version__ = getVersionNumber()
  File "/home/xvg/subhkl-examples/.venv/lib/python3.13/site-packages/careless/__init__.py", line 3, in getVersionNumber
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```
- relax tensorflow dependencies (2.20 works on py 3.13)