### PR TITLE
Handle anomalous .mtz files and find I/SigI keys if none were provided

### DIFF
--- a/careless/stats/cchalf.py
+++ b/careless/stats/cchalf.py
@@ -1,19 +1,19 @@
 """
 Compute CChalf from careless output.
 """
-import argparse
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
 import reciprocalspaceship as rs
 import seaborn as sns
 
-
 from careless.stats.parser import BaseParser
+from careless.utils.friedel import is_anomalous_output
+
+
 class ArgumentParser(BaseParser):
     def __init__(self):
-        super().__init__(
-            description=__doc__
-        )
+        super().__init__(description=__doc__)
 
         # Required arguments
         self.add_argument(
@@ -53,22 +53,23 @@ class ArgumentParser(BaseParser):
 
 
 def weighted_pearson_ccfunc(df, key="I"):
-    k1,k2 = f"{key}1",f"{key}2"
-    q1,q2 = f"Sig{key}1",f"Sig{key}2"
-    x = df[k1].to_numpy('float32')
-    y = df[k2].to_numpy('float32')
-    w = np.reciprocal(
-        np.square(df[q1]) + np.square(df[q2])
-    ).to_numpy('float32')
+    k1, k2 = f"{key}1", f"{key}2"
+    q1, q2 = f"Sig{key}1", f"Sig{key}2"
+    x = df[k1].to_numpy("float32")
+    y = df[k2].to_numpy("float32")
+    w = np.reciprocal(np.square(df[q1]) + np.square(df[q2])).to_numpy("float32")
     return rs.utils.weighted_pearsonr(x, y, w)
 
-def spearman_ccfunc(df, key='I'):
-    k1,k2 = f"{key}1",f"{key}2"
-    return df[[k1,k2]].corr(method='spearman')[k1][k2]
 
-def pearson_ccfunc(df, key='I'):
-    k1,k2 = f"{key}1",f"{key}2"
-    return df[[k1,k2]].corr(method='pearson')[k1][k2]
+def spearman_ccfunc(df, key="I"):
+    k1, k2 = f"{key}1", f"{key}2"
+    return df[[k1, k2]].corr(method="spearman")[k1][k2]
+
+
+def pearson_ccfunc(df, key="I"):
+    k1, k2 = f"{key}1", f"{key}2"
+    return df[[k1, k2]].corr(method="pearson")[k1][k2]
+
 
 def make_halves_cchalf(mtz, bins=10):
     """Construct half-datasets for computing CChalf"""
@@ -77,45 +78,53 @@ def make_halves_cchalf(mtz, bins=10):
     half2 = mtz.loc[mtz.half == 1].copy()
 
     # Support anomalous
-    if "F(+)" in half1.columns:
+    if is_anomalous_output(half1):
         half1 = half1.stack_anomalous()
         half2 = half2.stack_anomalous()
 
-    out = half1[["F", "SigF", "I", "SigI", "repeat"]].merge(
-        half2[["F", "SigF", "I", "SigI", "repeat"]], on=["H", "K", "L", "repeat"], suffixes=("1", "2")
-    ).dropna()
+    out = (
+        half1[["F", "SigF", "I", "SigI", "repeat"]]
+        .merge(
+            half2[["F", "SigF", "I", "SigI", "repeat"]],
+            on=["H", "K", "L", "repeat"],
+            suffixes=("1", "2"),
+        )
+        .dropna()
+    )
     return out
+
 
 def run_analysis(args):
     ds = []
     for m in args.mtz:
         _ds = rs.read_mtz(m)
-        _ds = _ds.rename(columns={
-            'SIGI' : 'SigI',
-            'SIGF' : 'SigF',
-        })
-        #non-isomorphism could lead to different resolution for each mtz
-        #need to calculate dHKL before concatenating 
+        _ds = _ds.rename(
+            columns={
+                "SIGI": "SigI",
+                "SIGF": "SigF",
+            }
+        )
+        # non-isomorphism could lead to different resolution for each mtz
+        # need to calculate dHKL before concatenating
         _ds = make_halves_cchalf(_ds)
         _ds.compute_dHKL(inplace=True)
-        _ds['file'] = m
-        _ds['Spacegroup'] = _ds.spacegroup.xhm()
+        _ds["file"] = m
+        _ds["Spacegroup"] = _ds.spacegroup.xhm()
         ds.append(_ds)
     ds = rs.concat(ds, check_isomorphous=False)
-    bins,edges = rs.utils.bin_by_percentile(ds.dHKL, args.bins, ascending=False)
-    ds['bin'] = bins
-    labels = [
-        f"{e1:0.2f} - {e2:0.2f}"
-        for e1, e2 in zip(edges[:-1], edges[1:])
-    ]
+    bins, edges = rs.utils.bin_by_percentile(ds.dHKL, args.bins, ascending=False)
+    ds["bin"] = bins
+    labels = [f"{e1:0.2f} - {e2:0.2f}" for e1, e2 in zip(edges[:-1], edges[1:])]
 
     if args.use_structure_factors:
-        ds = ds[["file", "bin", "repeat", "F1", "SigF1", "F2", "SigF2", "Spacegroup"]].rename(
+        ds = ds[
+            ["file", "bin", "repeat", "F1", "SigF1", "F2", "SigF2", "Spacegroup"]
+        ].rename(
             columns={
-                'F1' : 'I1',
-                'F2' : 'I2',
-                'SigF1' : 'SigI1',
-                'SigF2' : 'SigI2',
+                "F1": "I1",
+                "F2": "I2",
+                "SigF1": "SigI1",
+                "SigF2": "SigI2",
             }
         )
 
@@ -123,7 +132,6 @@ def run_analysis(args):
         grouper = ds.groupby(["bin", "repeat"])
     else:
         grouper = ds.groupby(["file", "bin", "repeat"])
-
 
     if args.method.lower() == "spearman":
         ccfunc = spearman_ccfunc
@@ -135,39 +143,44 @@ def run_analysis(args):
         raise ValueError(f"Unrecognized CC --method, {args.method}")
 
     result = grouper.apply(ccfunc)
-    result = rs.DataSet({"CChalf" : result}).reset_index()
-    result['Resolution Range (Å)'] = np.array(labels)[result.bin]
-    result['Spacegroup'] = grouper['Spacegroup'].apply('first').to_numpy()
+    result = rs.DataSet({"CChalf": result}).reset_index()
+    result["Resolution Range (Å)"] = np.array(labels)[result.bin]
+    result["Spacegroup"] = grouper["Spacegroup"].apply("first").to_numpy()
     if not args.overall:
-        result['file'] = grouper['file'].apply('first').to_numpy()
-        result = result[['file', 'repeat', 'Resolution Range (Å)', 'bin', 'Spacegroup', 'CChalf']]
+        result["file"] = grouper["file"].apply("first").to_numpy()
+        result = result[
+            ["file", "repeat", "Resolution Range (Å)", "bin", "Spacegroup", "CChalf"]
+        ]
     else:
-        result = result[['repeat', 'Resolution Range (Å)', 'bin', 'Spacegroup', 'CChalf']]
-
+        result = result[
+            ["repeat", "Resolution Range (Å)", "bin", "Spacegroup", "CChalf"]
+        ]
 
     if args.output is not None:
         result.to_csv(args.output)
     else:
         print(result.to_string())
-    
+
     plot_kwargs = {
-        'data' : result,
-        'x' : 'bin',
-        'y' : 'CChalf',
+        "data": result,
+        "x": "bin",
+        "y": "CChalf",
     }
 
     if args.overall:
-        plot_kwargs['color'] = 'k'
+        plot_kwargs["color"] = "k"
     else:
-        plot_kwargs['hue'] = 'file'
-        plot_kwargs['palette'] = "Dark2"
+        plot_kwargs["hue"] = "file"
+        plot_kwargs["palette"] = "Dark2"
 
     plt.figure(figsize=(args.width, args.height))
     sns.lineplot(**plot_kwargs)
-    plt.xticks(range(args.bins), labels, rotation=45, ha="right", rotation_mode="anchor")
+    plt.xticks(
+        range(args.bins), labels, rotation=45, ha="right", rotation_mode="anchor"
+    )
     plt.ylabel(r"$\mathrm{CC_{1/2}}$ " + f"({args.method})")
-    plt.xlabel("Resolution ($\mathrm{\AA}$)")
-    plt.grid(which='both', axis='both', ls='dashdot')
+    plt.xlabel(r"Resolution ($\mathrm{\AA}$)")
+    plt.grid(which="both", axis="both", ls="dashdot")
     if args.ylim is not None:
         plt.ylim(args.ylim)
     plt.tight_layout()
@@ -182,4 +195,3 @@ def run_analysis(args):
 def main():
     parser = ArgumentParser().parse_args()
     run_analysis(parser)
-

--- a/careless/stats/isigi.py
+++ b/careless/stats/isigi.py
@@ -11,6 +11,7 @@ import seaborn as sns
 
 from careless.io.formatter import get_first_key_of_dtype
 from careless.stats.parser import BaseParser
+from careless.utils.friedel import is_anomalous_output
 
 
 class ArgumentParser(BaseParser):
@@ -78,7 +79,7 @@ def run_analysis(args):
     ds["bin"] = bins
     labels = [f"{e1:0.2f} - {e2:0.2f}" for e1, e2 in zip(edges[:-1], edges[1:])]
 
-    if "F(+)" in ds.columns:
+    if is_anomalous_output(ds):
         ds = ds.stack_anomalous()
 
     ikey = args.I_col

--- a/careless/stats/isigi.py
+++ b/careless/stats/isigi.py
@@ -1,27 +1,27 @@
 """
 Compute I/sigI from careless output.
 """
-import argparse
-import numpy as np
-import matplotlib.pyplot as plt
-import reciprocalspaceship as rs
-import seaborn as sns
+
 import os
 
+import matplotlib.pyplot as plt
+import numpy as np
+import reciprocalspaceship as rs
+import seaborn as sns
 
 from careless.io.formatter import get_first_key_of_dtype
 from careless.stats.parser import BaseParser
+
+
 class ArgumentParser(BaseParser):
     def __init__(self):
-        super().__init__(
-            description=__doc__
-        )
+        super().__init__(description=__doc__)
 
         # Required arguments
         self.add_argument(
             "mtz",
             nargs="+",
-            help="MTZs containing crossvalidation data from careless",
+            help="MTZs containing merged data from careless",
         )
 
         self.add_argument(
@@ -64,71 +64,78 @@ def run_analysis(args):
     for m in args.mtz:
         _ds = rs.read_mtz(m)
         print(m)
-        #non-isomorphism could lead to different resolution for each mtz
-        #need to calculate dHKL before concatenating 
+        # non-isomorphism could lead to different resolution for each mtz
+        # need to calculate dHKL before concatenating
         _ds.compute_dHKL(inplace=True)
-        if len(m)<50:
-            _ds['file'] = m
+        if len(m) < 50:
+            _ds["file"] = m
         else:
-            _ds['file'] = os.path.basename(m)
-        _ds['Spacegroup'] = _ds.spacegroup.xhm()
+            _ds["file"] = os.path.basename(m)
+        _ds["Spacegroup"] = _ds.spacegroup.xhm()
         ds.append(_ds)
     ds = rs.concat(ds, check_isomorphous=False)
-    bins,edges = rs.utils.bin_by_percentile(ds.dHKL, args.bins, ascending=False)
-    ds['bin'] = bins
-    labels = [
-        f"{e1:0.2f} - {e2:0.2f}"
-        for e1, e2 in zip(edges[:-1], edges[1:])
-    ]
+    bins, edges = rs.utils.bin_by_percentile(ds.dHKL, args.bins, ascending=False)
+    ds["bin"] = bins
+    labels = [f"{e1:0.2f} - {e2:0.2f}" for e1, e2 in zip(edges[:-1], edges[1:])]
+
+    if "F(+)" in ds.columns:
+        ds = ds.stack_anomalous()
 
     ikey = args.I_col
+    sigkey = args.sigI_col
+
     if ikey is None:
-        ikey = get_first_key_of_dtype(ds, 'J')
-    sigkey=args.sigI_col
+        ikey = get_first_key_of_dtype(ds, "J")
+
     if sigkey is None:
-        sigkey = get_first_key_of_dtype(ds, 'Q')
-        
+        sigkey = get_first_key_of_dtype(ds, "Q")
+        for key in ds:
+            if ds[key].dtype == "Q" and key.endswith(ikey):
+                sigkey = key
+
     if args.overall:
         grouper = ds.groupby(["bin"])
     else:
         grouper = ds.groupby(["file", "bin"])
 
-    result = grouper.apply(lambda x : np.mean(x[ikey]/x[sigkey]))
-    result = rs.DataSet({"I/sigI" : result}).reset_index()
-    result['Resolution Range (Å)'] = np.array(labels)[result.bin]
-    result['Spacegroup'] = grouper['Spacegroup'].apply('first').to_numpy()
-    if not args.overall:
-        result['file'] = grouper['file'].apply('first').to_numpy()
-        result = result[['file', 'Resolution Range (Å)', 'bin', 'Spacegroup', 'I/sigI']]
-    else:
-        result = result[['Resolution Range (Å)', 'bin', 'Spacegroup', 'I/sigI']]
+    result = grouper.apply(lambda x: np.mean(x[ikey] / x[sigkey]))
+    result = rs.DataSet({"I/sigI": result}).reset_index()
+    result["Resolution Range (Å)"] = np.array(labels)[result.bin]
+    result["Spacegroup"] = grouper["Spacegroup"].apply("first").to_numpy()
 
+    if not args.overall:
+        result["file"] = grouper["file"].apply("first").to_numpy()
+        result = result[["file", "Resolution Range (Å)", "bin", "Spacegroup", "I/sigI"]]
+    else:
+        result = result[["Resolution Range (Å)", "bin", "Spacegroup", "I/sigI"]]
 
     if args.output is not None:
         result.to_csv(args.output)
     else:
         print(result.to_string())
-    
+
     plot_kwargs = {
-        'data' : result,
-        'x' : 'bin',
-        'y' : 'I/sigI',
+        "data": result,
+        "x": "bin",
+        "y": "I/sigI",
     }
 
     if args.overall:
-        plot_kwargs['color'] = 'k'
+        plot_kwargs["color"] = "k"
     else:
-        plot_kwargs['hue'] = 'file'
-        plot_kwargs['palette'] = "Dark2"
+        plot_kwargs["hue"] = "file"
+        plot_kwargs["palette"] = "Dark2"
 
     plt.figure(figsize=(args.width, args.height))
-    ax=sns.lineplot(**plot_kwargs)
+    ax = sns.lineplot(**plot_kwargs)
     if args.log:
-        ax.set(yscale='log')
-    plt.xticks(range(args.bins), labels, rotation=45, ha="right", rotation_mode="anchor")
+        ax.set(yscale="log")
+    plt.xticks(
+        range(args.bins), labels, rotation=45, ha="right", rotation_mode="anchor"
+    )
     plt.ylabel(r"$\mathrm{I/\sigma(I)}$ ")
-    plt.xlabel("Resolution ($\mathrm{\AA}$)")
-    plt.grid(which='both', axis='both', ls='dashdot')
+    plt.xlabel(r"Resolution ($\mathrm{\AA}$)")
+    plt.grid(which="both", axis="both", ls="dashdot")
     plt.ylim(args.ylim)
 
     plt.tight_layout()
@@ -144,6 +151,7 @@ def main():
     parser = ArgumentParser().parse_args()
     # print(parser)
     run_analysis(parser)
+
 
 if __name__ == "__main__":
     main()

--- a/careless/stats/rsplit.py
+++ b/careless/stats/rsplit.py
@@ -1,20 +1,20 @@
 """
 Compute CChalf from careless output.
 """
-import argparse
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
 import reciprocalspaceship as rs
 import seaborn as sns
 from scipy.optimize import minimize
 
-
 from careless.stats.parser import BaseParser
+from careless.utils.friedel import is_anomalous_output
+
+
 class ArgumentParser(BaseParser):
     def __init__(self):
-        super().__init__(
-            description=__doc__
-        )
+        super().__init__(description=__doc__)
 
         # Required arguments
         self.add_argument(
@@ -37,13 +37,16 @@ class ArgumentParser(BaseParser):
             help="Pool all prediction mtz files into a single calculation rather than treating each file individually.",
         )
 
+
 def rsplit(dataset):
-    x,y = dataset.F1.to_numpy(),dataset.F2.to_numpy()
+    x, y = dataset.F1.to_numpy(), dataset.F2.to_numpy()
+
     def rfunc(k):
         return np.sum(np.abs(x - k * y)) / np.sum(x + k * y)
 
-    p = minimize(rfunc, 1.)
-    return np.sqrt(2) * p.fun 
+    p = minimize(rfunc, 1.0)
+    return np.sqrt(2) * p.fun
+
 
 def make_halves_rsplit(mtz, bins=10):
     """Construct half-datasets for computing Rsplit"""
@@ -52,73 +55,82 @@ def make_halves_rsplit(mtz, bins=10):
     half2 = mtz.loc[mtz.half == 1].copy()
 
     # Support anomalous
-    if "F(+)" in half1.columns:
+    if is_anomalous_output(half1):
         half1 = half1.stack_anomalous()
         half2 = half2.stack_anomalous()
 
-    out = half1[["F", "SigF", "repeat"]].merge(
-        half2[["F", "SigF", "repeat"]], on=["H", "K", "L", "repeat"], suffixes=("1", "2")
-    ).dropna()
+    out = (
+        half1[["F", "SigF", "repeat"]]
+        .merge(
+            half2[["F", "SigF", "repeat"]],
+            on=["H", "K", "L", "repeat"],
+            suffixes=("1", "2"),
+        )
+        .dropna()
+    )
     return out
+
 
 def run_analysis(args):
     ds = []
     for m in args.mtz:
         _ds = rs.read_mtz(m)
-        #non-isomorphism could lead to different resolution for each mtz
-        #need to calculate dHKL before concatenating 
+        # non-isomorphism could lead to different resolution for each mtz
+        # need to calculate dHKL before concatenating
         _ds = make_halves_rsplit(_ds)
         _ds.compute_dHKL(inplace=True)
-        _ds['file'] = m
-        _ds['Spacegroup'] = _ds.spacegroup.xhm()
+        _ds["file"] = m
+        _ds["Spacegroup"] = _ds.spacegroup.xhm()
         ds.append(_ds)
     ds = rs.concat(ds, check_isomorphous=False)
-    bins,edges = rs.utils.bin_by_percentile(ds.dHKL, args.bins, ascending=False)
-    ds['bin'] = bins
-    labels = [
-        f"{e1:0.2f} - {e2:0.2f}"
-        for e1, e2 in zip(edges[:-1], edges[1:])
-    ]
+    bins, edges = rs.utils.bin_by_percentile(ds.dHKL, args.bins, ascending=False)
+    ds["bin"] = bins
+    labels = [f"{e1:0.2f} - {e2:0.2f}" for e1, e2 in zip(edges[:-1], edges[1:])]
 
     if args.overall:
         grouper = ds.groupby(["bin", "repeat"])
     else:
         grouper = ds.groupby(["file", "bin", "repeat"])
     result = grouper.apply(rsplit)
-    result = rs.DataSet({"Rsplit" : result}).reset_index()
-    result['Resolution Range (Å)'] = np.array(labels)[result.bin]
-    result['Spacegroup'] = grouper['Spacegroup'].apply('first').to_numpy()
+    result = rs.DataSet({"Rsplit": result}).reset_index()
+    result["Resolution Range (Å)"] = np.array(labels)[result.bin]
+    result["Spacegroup"] = grouper["Spacegroup"].apply("first").to_numpy()
     if not args.overall:
-        result['file'] = grouper['file'].apply('first').to_numpy()
-        result = result[['file', 'repeat', 'Resolution Range (Å)', 'bin', 'Spacegroup', 'Rsplit']]
+        result["file"] = grouper["file"].apply("first").to_numpy()
+        result = result[
+            ["file", "repeat", "Resolution Range (Å)", "bin", "Spacegroup", "Rsplit"]
+        ]
     else:
-        result = result[['repeat', 'Resolution Range (Å)', 'bin', 'Spacegroup', 'Rsplit']]
-
+        result = result[
+            ["repeat", "Resolution Range (Å)", "bin", "Spacegroup", "Rsplit"]
+        ]
 
     if args.output is not None:
         result.to_csv(args.output)
     else:
         print(result.to_string())
-    
+
     plot_kwargs = {
-        'data' : result,
-        'x' : 'bin',
-        'y' : 'Rsplit',
+        "data": result,
+        "x": "bin",
+        "y": "Rsplit",
     }
 
     if args.overall:
-        plot_kwargs['color'] = 'k'
+        plot_kwargs["color"] = "k"
     else:
-        plot_kwargs['hue'] = 'file'
-        plot_kwargs['palette'] = "Dark2"
+        plot_kwargs["hue"] = "file"
+        plot_kwargs["palette"] = "Dark2"
 
     plt.figure(figsize=(args.width, args.height))
     sns.lineplot(**plot_kwargs)
-    plt.xticks(range(args.bins), labels, rotation=45, ha="right", rotation_mode="anchor")
+    plt.xticks(
+        range(args.bins), labels, rotation=45, ha="right", rotation_mode="anchor"
+    )
     plt.ylabel(r"$R_{\mathrm{split}}$")
-    plt.xlabel("Resolution ($\mathrm{\AA}$)")
-    plt.legend(loc='upper left', borderaxespad=0)
-    plt.grid(which='both', axis='both', ls='dashdot')
+    plt.xlabel(r"Resolution ($\mathrm{\AA}$)")
+    plt.legend(loc="upper left", borderaxespad=0)
+    plt.grid(which="both", axis="both", ls="dashdot")
     plt.tight_layout()
     if args.ylim is not None:
         plt.ylim(args.ylim)
@@ -133,4 +145,3 @@ def run_analysis(args):
 def main():
     parser = ArgumentParser().parse_args()
     run_analysis(parser)
-

--- a/careless/utils/friedel.py
+++ b/careless/utils/friedel.py
@@ -1,13 +1,28 @@
 import pathlib
 from argparse import ArgumentParser
+
 import reciprocalspaceship as rs
+
 
 def get_split_friedel_parser():
     parser = ArgumentParser(description="Split an mtz into anomalous half datasets")
     parser.add_argument("unmerged_mtz", type=pathlib.Path)
-    parser.add_argument("-p", "--friedel-plus-mtz", help="Output mtz with Plus Friedel mates and centrics. Default 'friedel_plus.mtz'", default="friedel_plus.mtz", type=pathlib.Path)
-    parser.add_argument("-m", "--friedel-minus-mtz", help="Output mtz with Minus Friedel mates. Default 'friedel_minus.mtz'", default="friedel_minus.mtz", type=pathlib.Path)
+    parser.add_argument(
+        "-p",
+        "--friedel-plus-mtz",
+        help="Output mtz with Plus Friedel mates and centrics. Default 'friedel_plus.mtz'",
+        default="friedel_plus.mtz",
+        type=pathlib.Path,
+    )
+    parser.add_argument(
+        "-m",
+        "--friedel-minus-mtz",
+        help="Output mtz with Minus Friedel mates. Default 'friedel_minus.mtz'",
+        default="friedel_minus.mtz",
+        type=pathlib.Path,
+    )
     return parser
+
 
 def split_friedel(args=None):
     if args is None:
@@ -16,29 +31,34 @@ def split_friedel(args=None):
 
     ds = rs.read_mtz(str(args.unmerged_mtz))
     if ds.merged:
-        raise ValueError(f"Expected an unmerged Mtz, but {args.unmerged_mtz} is merged.")
+        raise ValueError(
+            f"Expected an unmerged Mtz, but {args.unmerged_mtz} is merged."
+        )
 
     # M/ISYM is part of the MTZ specification and can be used
     # to determine the sign of a Friedel mate. More info at:
     # https://www.ccp4.ac.uk/html/mtzformat.html#column-labels-and-standard-names
     # hkl_to_asu adds "M/ISYM" column and preserves row order
-    plus = (ds.hkl_to_asu()["M/ISYM"].to_numpy() % 2 == 1)
+    plus = ds.hkl_to_asu()["M/ISYM"].to_numpy() % 2 == 1
 
-    #The double-Wilson prior expects all the centrics in the friedel plus file
+    # The double-Wilson prior expects all the centrics in the friedel plus file
     centrics = ds.label_centrics().CENTRIC.to_numpy()
     plus_or_centric = plus | centrics
 
-    #from IPython import embed;embed(colors='linux')
+    # from IPython import embed;embed(colors='linux')
     ds[plus_or_centric].write_mtz(str(args.friedel_plus_mtz))
     ds[~plus_or_centric].write_mtz(str(args.friedel_minus_mtz))
 
 
 def get_combine_friedel_parser():
-    parser = ArgumentParser(description="Combine anomalous half datasets merged with careless into a single mtz")
+    parser = ArgumentParser(
+        description="Combine anomalous half datasets merged with careless into a single mtz"
+    )
     parser.add_argument("plus_mtz")
     parser.add_argument("minus_mtz")
     parser.add_argument("out_mtz")
     return parser
+
 
 def combine_friedel(args=None):
     if args is None:
@@ -50,33 +70,48 @@ def combine_friedel(args=None):
 
     # check whether this is a crossvalidation _xval.mtz format file
     # from careless. if so we need to make sure we retain the 'half'
-    # and 'repeat' columns to make it compatible with the stats 
+    # and 'repeat' columns to make it compatible with the stats
     # submodule
     is_xval_mtz = False
-    if ('repeat' in plus) and ('half' in plus):
+    if ("repeat" in plus) and ("half" in plus):
         is_xval_mtz = True
 
     anom_keys = [
-        'F(+)', 'SigF(+)', 'F(-)', 'SigF(-)', 
-        'I(+)', 'SigI(+)', 'I(-)', 'SigI(-)', 
-        'N(+)', 'N(-)',
+        "F(+)",
+        "SigF(+)",
+        "F(-)",
+        "SigF(-)",
+        "I(+)",
+        "SigI(+)",
+        "I(-)",
+        "SigI(-)",
+        "N(+)",
+        "N(-)",
     ]
 
-    out = rs.concat([
-        plus,
-        minus.apply_symop("-x,-y,-z"),
-    ])
+    out = rs.concat(
+        [
+            plus,
+            minus.apply_symop("-x,-y,-z"),
+        ]
+    )
+
     def unstack_anomalous(ds):
-        """ Unstack and reorder as phenix would expect"""
+        """Unstack and reorder as phenix would expect"""
         return ds.unstack_anomalous()[anom_keys]
 
     if is_xval_mtz:
-        group_keys = ['half', 'repeat']
-        cell,sg = out.cell,out.spacegroup
+        group_keys = ["half", "repeat"]
+        cell, sg = out.cell, out.spacegroup
         out = out.groupby(group_keys).apply(unstack_anomalous)
-        out.cell,out.spacegroup = cell,sg
+        out.cell, out.spacegroup = cell, sg
     else:
         out = unstack_anomalous(out)
 
     out.write_mtz(str(args.out_mtz))
 
+
+def is_anomalous_output(ds):
+    anom_keys = ["F(+)", "I(+)"]
+    if any(c in ds.columns for c in anom_keys):
+        return True

--- a/tests/stats/test_cc.py
+++ b/tests/stats/test_cc.py
@@ -1,11 +1,20 @@
-from careless.stats import cchalf,ccanom,ccpred,rsplit,image_cc,filter_by_image_cc,isigi
-from tempfile import TemporaryDirectory
-from os.path import exists
 from os import symlink
+from os.path import exists
+from tempfile import TemporaryDirectory
+
 import pandas as pd
 import pytest
 import reciprocalspaceship as rs
 
+from careless.stats import (
+    ccanom,
+    cchalf,
+    ccpred,
+    filter_by_image_cc,
+    image_cc,
+    isigi,
+    rsplit,
+)
 
 
 @pytest.mark.parametrize("bins", [1, 5])
@@ -25,7 +34,7 @@ def test_rsplit(xval_mtz, method, bins):
     assert exists(png)
 
     df = pd.read_csv(csv)
-    assert len(df) == 3*bins 
+    assert len(df) == 3 * bins
 
 
 @pytest.mark.parametrize("bins", [1, 5])
@@ -35,7 +44,7 @@ def test_cchalf(xval_mtz, method, bins, use_structure_factors):
     tf = TemporaryDirectory()
     csv = f"{tf.name}/out.csv"
     png = f"{tf.name}/out.png"
-    sf = ''
+    sf = ""
     if use_structure_factors:
         sf = "--use-structure-factors"
 
@@ -50,7 +59,7 @@ def test_cchalf(xval_mtz, method, bins, use_structure_factors):
     assert exists(png)
 
     df = pd.read_csv(csv)
-    assert len(df) == 3*bins 
+    assert len(df) == 3 * bins
 
 
 @pytest.mark.parametrize("bins", [1, 5])
@@ -70,7 +79,7 @@ def test_ccanom(xval_mtz, method, bins):
     assert exists(png)
 
     df = pd.read_csv(csv)
-    assert len(df) == 3*bins 
+    assert len(df) == 3 * bins
 
 
 @pytest.mark.parametrize("bins", [1, 5])
@@ -83,11 +92,11 @@ def test_ccpred(predictions_mtz, method, bins, overall, multi):
     png = f"{tf.name}/out.png"
     command = f"-o {csv} -i {png} -b {bins} "
     if overall:
-        command = command + ' --overall '
+        command = command + " --overall "
 
     if multi:
-        mtz_0 = f'{tf.name}/test_predictions_0.mtz'
-        mtz_1 = f'{tf.name}/test_predictions_1.mtz'
+        mtz_0 = f"{tf.name}/test_predictions_0.mtz"
+        mtz_1 = f"{tf.name}/test_predictions_1.mtz"
         symlink(predictions_mtz, mtz_0)
         symlink(predictions_mtz, mtz_1)
         command = command + f" {mtz_0} "
@@ -106,9 +115,10 @@ def test_ccpred(predictions_mtz, method, bins, overall, multi):
     df = pd.read_csv(csv)
 
     if multi and not overall:
-        assert len(df) == 4*bins 
+        assert len(df) == 4 * bins
     else:
-        assert len(df) == 2*bins
+        assert len(df) == 2 * bins
+
 
 @pytest.mark.parametrize("bins", [1, 5])
 @pytest.mark.parametrize("overall", [True, False])
@@ -120,11 +130,11 @@ def test_isigi(predictions_mtz, method, bins, overall, multi):
     png = f"{tf.name}/out.png"
     command = f"-o {csv} -i {png} -b {bins} "
     if overall:
-        command = command + ' --overall '
+        command = command + " --overall "
 
     if multi:
-        mtz_0 = f'{tf.name}/test_predictions_0.mtz'
-        mtz_1 = f'{tf.name}/test_predictions_1.mtz'
+        mtz_0 = f"{tf.name}/out_0.mtz"
+        mtz_1 = f"{tf.name}/out_1.mtz"
         symlink(predictions_mtz, mtz_0)
         symlink(predictions_mtz, mtz_1)
         command = command + f" {mtz_0} "
@@ -143,9 +153,9 @@ def test_isigi(predictions_mtz, method, bins, overall, multi):
     df = pd.read_csv(csv)
 
     if multi and not overall:
-        assert len(df) == 2*bins 
+        assert len(df) == 2 * bins
     else:
-        assert len(df) == 1*bins
+        assert len(df) == 1 * bins
 
 
 @pytest.mark.parametrize("method", ["weighted", "spearman", "pearson"])
@@ -157,8 +167,8 @@ def test_image_cc(predictions_mtz, method, multi):
     command = f"-o {csv} -i {png} "
 
     if multi:
-        mtz_0 = f'{tf.name}/test_predictions_0.mtz'
-        mtz_1 = f'{tf.name}/test_predictions_1.mtz'
+        mtz_0 = f"{tf.name}/test_predictions_0.mtz"
+        mtz_1 = f"{tf.name}/test_predictions_1.mtz"
         symlink(predictions_mtz, mtz_0)
         symlink(predictions_mtz, mtz_1)
         command = command + f" {mtz_0} "
@@ -175,6 +185,7 @@ def test_image_cc(predictions_mtz, method, multi):
     assert exists(png)
 
     df = pd.read_csv(csv)
+
 
 @pytest.mark.parametrize("method", ["weighted", "spearman", "pearson"])
 def test_filter_by_image_cc(predictions_mtz, method, off_file, on_file):
@@ -194,4 +205,3 @@ def test_filter_by_image_cc(predictions_mtz, method, off_file, on_file):
 
     rs.read_mtz(out_1)
     rs.read_mtz(out_2)
-


### PR DESCRIPTION
Added a line to check if the 'F(+)' key is in the provided `.mtz` file. If found, the anomalous pairs are stacked. 

Additionally, the file will now try to find `I` and `SigI` keys if none were provided. 

NOTE: My parser made a lot of extra changes; the main changes are on lines 81-95.  I can revert the formatting changes if you'd like.

Closes #204 